### PR TITLE
List-group-heading combined with collapse js should have same bg colo…

### DIFF
--- a/src/scss/atlas-theme/_list-group.scss
+++ b/src/scss/atlas-theme/_list-group.scss
@@ -18,7 +18,8 @@
 	}
 }
 
-a.list-group-heading {
+a.list-group-heading,
+.list-group-heading[data-toggle="collapse"] {
 	color: $list-group-header-color;
 
 	&:focus,


### PR DESCRIPTION
…r when focus or hovered

On page http://liferay.github.io/lexicon/content/blogs-appearance/ hovering or focusing List Group Heading causes background color to change. It should stay the same.