### PR TITLE
Rename cells to table-list-field and table-list-content, also vertica…

### DIFF
--- a/src/content/tables.html
+++ b/src/content/tables.html
@@ -15,29 +15,29 @@ section: Elements
 		<table class="table table-list">
 			<thead>
 				<tr>
-					<th class="checkbox-cell"></th>
-					<th class="text-cell"><span class="truncate-text">Description</span></th>
-					<th class="label-cell">Format</th>
-					<th class="label-cell">Label</th>
-					<th class="label-cell">Label</th>
-					<th class="checkbox-cell"></th>
+					<th class="table-list-field"></th>
+					<th class="table-list-content"><span class="truncate-text">Description</span></th>
+					<th class="table-list-field">Format</th>
+					<th class="table-list-field">Label</th>
+					<th class="table-list-field">Label</th>
+					<th class="table-list-field"></th>
 				</tr>
 			</thead>
 
 			<tbody>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -52,18 +52,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr class="active">
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input checked class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Pumpkin spice and, java sit whipped grinder steamed.">Pumpkin spice and, java sit whipped grinder steamed.</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -78,18 +78,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Frappuccino medium americano">Frappuccino medium americano</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -104,18 +104,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Cultivar extra">Cultivar extra</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -137,29 +137,29 @@ section: Elements
 		<table class="table table-list table-striped">
 			<thead>
 				<tr>
-					<th class="checkbox-cell"></th>
-					<th class="text-cell"><span class="truncate-text">Description</span></th>
-					<th class="label-cell">Format</th>
-					<th class="label-cell">Label</th>
-					<th class="label-cell">Label</th>
-					<th class="checkbox-cell"></th>
+					<th class="table-list-field"></th>
+					<th class="table-list-content"><span class="truncate-text">Description</span></th>
+					<th class="table-list-field">Format</th>
+					<th class="table-list-field">Label</th>
+					<th class="table-list-field">Label</th>
+					<th class="table-list-field"></th>
 				</tr>
 			</thead>
 
 			<tbody>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -174,18 +174,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Pumpkin spice and, java sit whipped grinder steamed.">Pumpkin spice and, java sit whipped grinder steamed.</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -200,18 +200,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Frappuccino medium americano">Frappuccino medium americano</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -226,18 +226,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Cultivar extra">Cultivar extra</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -259,29 +259,29 @@ section: Elements
 		<table class="table table-list table-hover">
 			<thead>
 				<tr>
-					<th class="checkbox-cell"></th>
-					<th class="text-cell"><span class="truncate-text" title="Description">Description</span></th>
-					<th class="label-cell">Format</th>
-					<th class="label-cell">Label</th>
-					<th class="label-cell">Label</th>
-					<th class="checkbox-cell"></th>
+					<th class="table-list-field"></th>
+					<th class="table-list-content"><span class="truncate-text" title="Description">Description</span></th>
+					<th class="table-list-field">Format</th>
+					<th class="table-list-field">Label</th>
+					<th class="table-list-field">Label</th>
+					<th class="table-list-field"></th>
 				</tr>
 			</thead>
 
 			<tbody>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -296,18 +296,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr class="active">
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input checked class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Pumpkin spice and, java sit whipped grinder steamed.">Pumpkin spice and, java sit whipped grinder steamed.</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -322,18 +322,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Frappuccino medium americano">Frappuccino medium americano</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">
@@ -348,18 +348,18 @@ section: Elements
 					</td>
 				</tr>
 				<tr>
-					<td class="checkbox-cell">
+					<td class="table-list-field">
 						<label class="checkbox-default">
 							<input class="input-sm" type="checkbox" value="">
 						</label>
 					</td>
-					<td class="text-cell">
+					<td class="table-list-content">
 						<span class="truncate-text" title="Cultivar extra">Cultivar extra</span>
 					</td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="label-cell"><a href="#1">jpg</a></td>
-					<td class="checkbox-cell">
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field"><a href="#1">jpg</a></td>
+					<td class="table-list-field">
 						<div class="dropdown">
 							<a class="dropdown-toggle" data-toggle="dropdown" href="#1"><span class="icon-ellipsis-vertical icon-monospaced"></span></a>
 							<ul class="dropdown-menu dropdown-menu-left-side">

--- a/src/scss/lexicon-base/_tables.scss
+++ b/src/scss/lexicon-base/_tables.scss
@@ -163,11 +163,18 @@
 // Table List Skin
 
 .table-list {
-	table-layout: fixed;
-
 	> thead > tr > td,
 	> thead > tr > th {
 		border-bottom-width: 0;
+
+		&.table-list-content {
+			.truncate-text {
+				bottom: 10px;
+				line-height: normal;
+				margin-top: 0;
+				top: auto;
+			}
+		}
 	}
 
 	> tbody > tr > td,
@@ -203,37 +210,20 @@
 		margin-bottom: 0;
 	}
 
-	.checkbox-cell {
-		width: 48px;
+	.table-list-content {
+		position: relative;
+
+		.truncate-text {
+			left: 0;
+			line-height: $table-list-content-height;
+			margin-top: -(ceil($table-list-content-height / 2));
+			position: absolute;
+			right: 0;
+			top: 50%;
+		}
 	}
 
-	.label-cell {
-		@media screen and (min-width: $grid-float-breakpoint) {
-			width: 100px;
-		}
-
-		@media screen and (min-width: $screen-lg) {
-			width: 140px;
-		}
-	}
-}
-
-.table-responsive {
-	.table-list {
-		.label-cell {
-			width: 75px;
-
-			@media screen and (min-width: $screen-lg) {
-				width: 140px;
-			}
-		}
-
-		.text-cell {
-			width: 200px;
-
-			@media screen and (min-width: $grid-float-breakpoint) {
-				width: auto;
-			}
-		}
+	.table-list-field {
+		width: 1%;
 	}
 }

--- a/src/scss/lexicon-base/variables/_tables.scss
+++ b/src/scss/lexicon-base/variables/_tables.scss
@@ -1,3 +1,5 @@
+$table-list-content-height: 50px;
+
 $table-list-row-border-bottom-width: 1px !default;
 $table-list-row-active-border-bottom-width: 1px !default;
 


### PR DESCRIPTION
…lly center table-list-content with top: 50%

http://liferay.github.io/lexicon/content/tables/ implementation requires a fixed width to be set on each table cell, except for the cell that contains the truncated text. This new implementation is more fluid and doesn't require the user to set any width on a cell at the expense of vertically aligning content using the css property vertical-align. @marcoscv-work also requested we change the class name checkbox-cell to something less specific.