### PR TITLE
Remove old flexbox card styles

### DIFF
--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -294,34 +294,6 @@
 	}
 }
 
-// Toggle DM Cards
-
-.card-horizontal-flex.toggle-card-dm {
-	.toggle-card-container {
-		@include display(flex);
-	}
-
-	.aspect-ratio {
-		@include flex(0 1 auto);
-
-		padding-bottom: 0;
-
-		&:first-child {
-			border-radius: 4px 0 0 4px;
-		}
-	}
-
-	.card-header,
-	.card-footer,
-	.card-section {
-		@include flex(1);
-	}
-}
-
-.card-dm .card-footer {
-	@include display(flex);
-}
-
 // Flexbox Cards
 
 .checkbox-card {


### PR DESCRIPTION
Vertical ellipsis on http://liferay.github.io/lexicon/content/documents-and-media/ are aligned left instead of right. This is due to some old flexbox card styles that weren't deleted.