### PR TITLE
Aspect ratio bg cover

### DIFF
--- a/src/content/extending_cards.html
+++ b/src/content/extending_cards.html
@@ -14,7 +14,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/thumbnail_coffee.jpg);">
+					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/thumbnail_coffee.jpg);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">
@@ -44,7 +44,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/switch_on_icon.png);">
+					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/switch_on_icon.png);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">
@@ -74,7 +74,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/tv-at-beach.png);">
+					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/tv-at-beach.png);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">
@@ -104,7 +104,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/liferay_logo_tagline.png);">
+					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/liferay_logo_tagline.png);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">

--- a/src/content/extending_cards.html
+++ b/src/content/extending_cards.html
@@ -14,7 +14,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/thumbnail_coffee.jpg);">
+					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/thumbnail_coffee.jpg);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">
@@ -44,7 +44,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/switch_on_icon.png);">
+					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/switch_on_icon.png);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">
@@ -74,7 +74,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/tv-at-beach.png);">
+					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/tv-at-beach.png);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">
@@ -104,7 +104,7 @@ section: Extending Components
 			<label>
 				<input type="checkbox" value="">
 				<div class="toggle-card-container card card-dm">
-					<div class="aspect-ratio aspect-ratio-bg-center aspect-ratio-bg-cover" style="background-image:url(../../images/liferay_logo_tagline.png);">
+					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/liferay_logo_tagline.png);">
 						<span class="sticker sticker-warning sticker-bottom">PNG</span>
 					</div>
 					<div class="card-footer">

--- a/src/scss/lexicon-base/_aspect-ratio.scss
+++ b/src/scss/lexicon-base/_aspect-ratio.scss
@@ -59,11 +59,12 @@
 }
 
 .aspect-ratio-bg-cover {
+	background-position: center;
 	background-repeat: no-repeat;
 	background-size: cover;
 }
 
 .aspect-ratio-bg-center {
-	background-repeat: no-repeat;
 	background-position: center;
+	background-repeat: no-repeat;
 }


### PR DESCRIPTION
On http://liferay.github.io/lexicon/content/extending-cards/#cards-with-background-image-that-fills-remaining-space, images should be centered by default.