### PR TITLE
LPS-59013 hidden-xs class deleted

### DIFF
--- a/src/content/header.html
+++ b/src/content/header.html
@@ -92,7 +92,7 @@ section: Components
 					<a class="sidenav-toggler" href="#1"><span class="icon-align-justify icon-monospaced"></span></a>
 				</div>
 
-				<div class="toolbar-group-content hidden-xs">
+				<div class="toolbar-group-content">
 					<a href="#"><span class="icon-angle-left icon-monospaced"></span></a>
 				</div>
 			</div>
@@ -411,7 +411,7 @@ section: Components
 								<a class="sidenav-toggler" href="#1"><span class="icon-align-justify icon-monospaced"></span></a>
 							</div>
 
-							<div class="toolbar-group-content hidden-xs">
+							<div class="toolbar-group-content">
 								<a href="#"><span class="icon-angle-left icon-monospaced"></span></a>
 							</div>
 						</div>


### PR DESCRIPTION
Removes hidden-xs class on left angle bracket from header toolbar. Juan decided to keep it visible in mobile.