### PR TITLE
Form Control Validation shouldn't bleed into nested form-groups

### DIFF
--- a/src/scss/lexicon-base/_form-validation.scss
+++ b/src/scss/lexicon-base/_form-validation.scss
@@ -1,13 +1,67 @@
-.validation-message {
-	.has-error & {
-		color: $state-danger-text;
+// Bootstrap Form Control Validation Reset
+// TWBS won't fix. See https://github.com/twbs/bootstrap/pull/17897
+
+.has-error,
+.has-success,
+.has-warning {
+	.help-block,
+	.control-label,
+	.radio,
+	.checkbox,
+	.radio-inline,
+	.checkbox-inline,
+	&.radio label,
+	&.checkbox label,
+	&.radio-inline label,
+	&.checkbox-inline label {
+		color: $input-color;
 	}
 
-	.has-success & {
+	.form-control {
+		border-color: $input-border;
+
+		&:focus {
+			$color-rgba: rgba(red($input-border-focus), green($input-border-focus), blue($input-border-focus), 0.6);
+
+			border-color: $input-border-focus;
+			-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px $color-rgba; // Undo from Bootstrap _vendor-prefixes mixin
+			box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px $color-rgba;
+		}
+	}
+
+	.input-group-addon {
+		color: $input-color;
+		border-color: $input-group-addon-border-color;
+		background-color: $input-group-addon-bg;
+	}
+
+	.form-control-feedback {
+		color: $text-color;
+	}
+}
+
+// Redo Bootstrap Form Control Validation
+
+.has-success {
+	@include form-control-validation($state-success-text, $state-success-text, $state-success-bg);
+
+	.validation-message {
 		color: $state-success-text;
 	}
+}
 
-	.has-warning & {
+.has-warning {
+	@include form-control-validation($state-warning-text, $state-warning-text, $state-warning-bg);
+
+	.validation-message {
 		color: $state-warning-text;
+	}
+}
+
+.has-error {
+	@include form-control-validation($state-danger-text, $state-danger-text, $state-danger-bg);
+
+	.validation-message {
+		color: $state-danger-text;
 	}
 }

--- a/src/scss/lexicon-base/_mixins.scss
+++ b/src/scss/lexicon-base/_mixins.scss
@@ -1,5 +1,6 @@
 @import "mixins/aspect-ratio";
 @import "mixins/figures";
+@import "mixins/forms";
 @import "mixins/list-group";
 @import "mixins/monospace";
 @import "mixins/nameplates";

--- a/src/scss/lexicon-base/mixins/_forms.scss
+++ b/src/scss/lexicon-base/mixins/_forms.scss
@@ -1,0 +1,43 @@
+/**
+ * Colors form labels and inputs
+ * @param $text-color - Label, Input Group Addon, and Form Control Feedback color
+ * @param $border-color - Form Control and Input Group Addon Border Color
+ * @param $background-color - Input Group Addon background-color
+ */
+
+@mixin form-control-validation($text-color: #555, $border-color: #CCC, $background-color: #F5F5F5) {
+	> .help-block,
+	> .control-label,
+	> .radio,
+	> .checkbox,
+	> .radio-inline,
+	> .checkbox-inline,
+	&.radio > label,
+	&.checkbox > label,
+	&.radio-inline > label,
+	&.checkbox-inline > label {
+		color: $text-color;
+	}
+
+	> .form-control {
+		border-color: $border-color;
+		box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+
+		&:focus {
+			$shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px lighten($border-color, 20%);
+
+			border-color: darken($border-color, 10%);
+			box-shadow: $shadow;
+		}
+	}
+
+	> .input-group-addon {
+		background-color: $background-color;
+		border-color: $border-color;
+		color: $text-color;
+	}
+
+	> .form-control-feedback {
+		color: $text-color;
+	}
+}


### PR DESCRIPTION
A form-group nested inside a form-group (http://liferay.github.io/lexicon/content/form-validation/) with form validation will inherit styles from its parent.

https://issues.liferay.com/browse/LPS-54946