### PR TITLE
Add background-color to card.

### DIFF
--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -48,6 +48,7 @@
 }
 
 .card-horizontal {
+	background-color: $card-vertical;
 	position: relative;
 
 	&.card-circle {
@@ -217,6 +218,7 @@
 // Card Skins
 
 .card-dm {
+	background-color: $card-dm;
 	overflow: visible;
 
 	.card-footer {

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -1,5 +1,6 @@
 .card,
 .card-horizontal {
+	background-color: $card-bg;
 	border: $card-border-width solid $card-border;
 	border-radius: $card-border-radius;
 	margin-bottom: $card-margin-bottom;
@@ -48,7 +49,6 @@
 }
 
 .card-horizontal {
-	background-color: $card-vertical;
 	position: relative;
 
 	&.card-circle {
@@ -218,7 +218,6 @@
 // Card Skins
 
 .card-dm {
-	background-color: $card-dm;
 	overflow: visible;
 
 	.card-footer {

--- a/src/scss/lexicon-base/variables/_cards.scss
+++ b/src/scss/lexicon-base/variables/_cards.scss
@@ -4,8 +4,10 @@ $card-border-width: 1px !default;
 $card-border-radius: $border-radius-base !default;
 
 $card-circle-border-radius: 20px !default;
+$card-dm: $body-bg !default;
 $card-rounded-border-radius: 4px !default;
 $card-square-border-radius: 0 !default;
+$card-vertical: $body-bg !default;
 
 $card-divider-bg: $card-border !default;
 $card-divider-height: 1px !default;

--- a/src/scss/lexicon-base/variables/_cards.scss
+++ b/src/scss/lexicon-base/variables/_cards.scss
@@ -1,17 +1,16 @@
-$card-border: $gray-lighter !default;
 $card-border-width: 1px !default;
+$card-divider-height: 1px !default;
+$card-gutter-width: 10px !default;
+$card-margin-bottom: $line-height-computed !default;
 
+// Skin
+
+$card-bg: #FFF !default;
+$card-border: $gray-lighter !default;
 $card-border-radius: $border-radius-base !default;
 
 $card-circle-border-radius: 20px !default;
-$card-dm: $body-bg !default;
 $card-rounded-border-radius: 4px !default;
 $card-square-border-radius: 0 !default;
-$card-vertical: $body-bg !default;
 
 $card-divider-bg: $card-border !default;
-$card-divider-height: 1px !default;
-
-$card-gutter-width: 10px !default;
-
-$card-margin-bottom: $line-height-computed !default;


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/extending-cards/ have no background-color by default. It doesn't fit well if the body's background-color is another color other than white.