### PR TITLE
Atlas control-label class should be styled like label and fix html cl…

### DIFF
--- a/src/content/form_elements.html
+++ b/src/content/form_elements.html
@@ -159,7 +159,7 @@ Checkboxes unable to be styled in IE with this method. -->
 
 <div class="row row-spacing">
 	<div class="col-md-12">
-		<h3>Select Box</h4>
+		<h3>Select Box</h3>
 
 		<div class="form-group">
 			<label>Regular Select Box</label>

--- a/src/scss/atlas-theme/_forms.scss
+++ b/src/scss/atlas-theme/_forms.scss
@@ -1,4 +1,5 @@
-label {
+label,
+.control-label {
 	color: $input-label-color;
 	font-size: $input-label-font-size;
 	font-weight: 500;


### PR DESCRIPTION
…osing tag in docs

Hey @natecavanaugh, there are no examples in Lexicon where we use the class ```control-label``` without the label element, but in portal there are cases like ```<span class="control-label"> Radio </span>``` to label a group of radio buttons.