### PR TITLE
Atlas: color dropdown-toggle icon-ellipsis-vertical only in cards

### DIFF
--- a/src/scss/atlas-theme/_cards.scss
+++ b/src/scss/atlas-theme/_cards.scss
@@ -1,6 +1,13 @@
 .card,
 .card-horizontal {
 	box-shadow: $card-box-shadow;
+
+	.dropdown-toggle {
+		&.icon-ellipsis-vertical,
+		.icon-ellipsis-vertical {
+			color: $dropdown-link-color;
+		}
+	}
 }
 
 .checkbox-default {

--- a/src/scss/atlas-theme/_dropdowns.scss
+++ b/src/scss/atlas-theme/_dropdowns.scss
@@ -20,13 +20,6 @@
 	}
 }
 
-.dropdown-toggle {
-	&.icon-ellipsis-vertical,
-	.icon-ellipsis-vertical {
-		color: $dropdown-link-color;
-	}
-}
-
 // Dropdown inline-scroller
 
 .dropdown-menu {


### PR DESCRIPTION
ae8421c introduced a bug that changes the colors on all dropdown-toggle icon-ellipsis. This narrows the color change only down to items inside cards.