### PR TITLE
Atlas header-toolbar-default divider shouldnt show if there is only o…

### DIFF
--- a/src/scss/atlas-theme/_toolbars.scss
+++ b/src/scss/atlas-theme/_toolbars.scss
@@ -71,8 +71,8 @@
 	.toolbar-group:first-child {
 		.toolbar-group-content,
 		.toolbar-group-field {
-			&:first-child {
-				border-right: 1px solid rgba(255, 255, 255, 0.05);
+			&:nth-of-type(2) {
+				border-left: $header-toolbar-default-divider-width solid $header-toolbar-default-divider;
 			}
 		}
 	}

--- a/src/scss/atlas-theme/variables/_toolbars.scss
+++ b/src/scss/atlas-theme/variables/_toolbars.scss
@@ -13,6 +13,8 @@ $header-toolbar-default-border-width: 0 !default; // Shared
 
 $header-toolbar-default-bg: #29343D !default; // Shared
 $header-toolbar-default-color: #FFF !default; // Shared
+$header-toolbar-default-divider: rgba(255, 255, 255, 0.05) !default;
+$header-toolbar-default-divider-width: 1px !default;
 
 $header-toolbar-default-link-color: #FFF !default; // Shared
 $header-toolbar-default-link-hover-bg: transparent !default; // Shared


### PR DESCRIPTION
…ne item

http://liferay.github.io/lexicon/content/header/#header-toolbar-default

Border shouldn't show if there is only one item in the first toolbar-group.