### PR TITLE
Update tab order and highlights

### DIFF
--- a/src/content/management-bar.html
+++ b/src/content/management-bar.html
@@ -29,12 +29,6 @@ section: Components
 				</a>
 			</div>
 
-			<div class="management-bar-header-right">
-				<a class="btn" href="#"><span class="icon-th-large icon-monospaced"></span></a>
-				<a class="btn" href="#"><span class="icon-th-list icon-monospaced"></span></a>
-				<a class="btn hidden-xs" href="#"><span class="icon-th icon-monospaced"></span></a>
-			</div>
-
 			<div class="collapse management-bar-collapse" id="mgmtBarCollapse00">
 				<ul class="nav management-bar-nav">
 					<li class="dropdown">
@@ -125,6 +119,12 @@ section: Components
 					</li>
 				</ul>
 			</div>
+
+			<div class="management-bar-header-right">
+				<a class="btn" href="#"><span class="icon-th-large icon-monospaced"></span></a>
+				<a class="btn" href="#"><span class="icon-th-list icon-monospaced"></span></a>
+				<a class="btn hidden-xs" href="#"><span class="icon-th icon-monospaced"></span></a>
+			</div>
 		</div>
 	</div>
 </div>
@@ -147,12 +147,6 @@ section: Components
 					<span class="management-bar-item-title">Label</span>
 					<span class="icon-sort">
 				</a>
-			</div>
-
-			<div class="management-bar-header-right">
-				<a class="btn" href="#"><span class="icon-th-large icon-monospaced"></span></a>
-				<a class="btn" href="#"><span class="icon-th-list icon-monospaced"></span></a>
-				<a class="btn hidden-xs" href="#"><span class="icon-th icon-monospaced"></span></a>
 			</div>
 
 			<div class="collapse management-bar-collapse" id="mgmtBarCollapse0">
@@ -244,6 +238,12 @@ section: Components
 						<a class="btn hidden-xs" href="#1"><span class="icon-caret-down icon-monospaced"></span></a>
 					</li>
 				</ul>
+			</div>
+
+			<div class="management-bar-header-right">
+				<a class="btn" href="#"><span class="icon-th-large icon-monospaced"></span></a>
+				<a class="btn" href="#"><span class="icon-th-list icon-monospaced"></span></a>
+				<a class="btn hidden-xs" href="#"><span class="icon-th icon-monospaced"></span></a>
 			</div>
 		</div>
 	</div>

--- a/src/scss/_site.scss
+++ b/src/scss/_site.scss
@@ -752,6 +752,10 @@ h1, h2, h3, h4, h5, h6 {
 			float: none;
 			opacity: 0;
 			margin-left: -20px;
+
+			&:focus {
+				opacity: 1;
+			}
 		}
 
 		&:hover .heading-anchor {

--- a/src/scss/atlas-theme/_navbar.scss
+++ b/src/scss/atlas-theme/_navbar.scss
@@ -177,7 +177,6 @@
 	.navbar .navbar-collapse {
 		background-color: transparent;
 		border-width: 0;
-		float: none;
 		left: auto;
 		position: static;
 		right: auto;

--- a/src/scss/lexicon-base/_dropdowns.scss
+++ b/src/scss/lexicon-base/_dropdowns.scss
@@ -47,7 +47,15 @@
 	}
 }
 
+.dropdown-menu > .active > a:focus {
+	@include tab-focus;
+}
+
 .dropdown-toggle {
+	&:focus {
+		@include tab-focus;
+	}
+
 	&:focus,
 	&:hover {
 		text-decoration: none;

--- a/src/scss/lexicon-base/_management-bar.scss
+++ b/src/scss/lexicon-base/_management-bar.scss
@@ -60,6 +60,12 @@
 	float: right;
 }
 
+.management-bar .management-bar-collapse {
+	@media screen and (min-width: $grid-float-breakpoint) {
+		float: left;
+	}
+}
+
 // management bar headers
 
 .management-bar-header,
@@ -112,6 +118,10 @@
 
 .management-bar-toggle {
 	@extend .navbar-toggle;
+
+	&:focus {
+		@include tab-focus;
+	}
 }
 
 .management-bar-toggle-link {

--- a/src/scss/lexicon-base/_navbar.scss
+++ b/src/scss/lexicon-base/_navbar.scss
@@ -100,6 +100,13 @@
 	}
 }
 
+// Bootstrap Navbar Overrides
+
+.navbar-brand:focus {
+	position: relative;
+	z-index: 1;
+}
+
 // Navbar Collapse Basic Search Styles
 
 .collapse-basic-search {

--- a/src/scss/lexicon-base/_navbar.scss
+++ b/src/scss/lexicon-base/_navbar.scss
@@ -200,7 +200,6 @@
 		@media screen and (min-width: $grid-float-breakpoint) {
 			background-color: transparent;
 			border-width: 0;
-			float: none;
 			left: auto;
 			position: static;
 			right: auto;

--- a/src/scss/lexicon-base/_navs.scss
+++ b/src/scss/lexicon-base/_navs.scss
@@ -1,3 +1,8 @@
+.nav > li > a:focus {
+	position: relative;
+	z-index: 1;
+}
+
 .nav > li > .collapse-icon {
 	padding-right: $nav-link-padding-horizontal * 2;
 


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/management-bar/ focus order should be correct.

The heading identifiers should show on focus.

Dropdown-toggles should have outline on focus. Examples at:
http://liferay.github.io/lexicon/content/navbar/
http://liferay.github.io/lexicon/content/header/
http://liferay.github.io/lexicon/content/list-groups/

