### PR TITLE
Remove link-group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Breaking: Remove link-group
+
 ## v0.1.21 - October 30, 2015
 
 * New: Add sizes sm, default,  md, lg to Lexicon icons

--- a/src/content/extending_cards.html
+++ b/src/content/extending_cards.html
@@ -362,9 +362,7 @@ section: Extending Components
 			<div class="divider"></div>
 
 			<div class="card-footer">
-				<div class="link-group" style="margin-top:0;">
-					<a href="#" class="btn btn-default btn-block" role="button">Subscribe</a>
-				</div>
+				<a class="btn btn-default btn-block" href="#" role="button" style="margin-bottom:10px;">Subscribe</a>
 			</div>
 		</div>
 	</div>
@@ -459,9 +457,9 @@ section: Extending Components
 
 					<div class="divider"></div>
 
-					<div class="link-group">
-						<button type="button" class="btn btn-primary btn-xs">Sign Up</button>
-						<button type="button" class="btn btn-link btn-xs">No Thanks</button>
+					<div style="margin: 10px 0;">
+						<button class="btn btn-primary btn-xs" type="button">Sign Up</button>
+						<button class="btn btn-link btn-xs" type="button">No Thanks</button>
 					</div>
 				</div>
 			</div>
@@ -490,9 +488,9 @@ section: Extending Components
 
 					<div class="divider"></div>
 
-					<div class="link-group">
-						<button type="button" class="btn btn-primary btn-xs">Sign Up</button>
-						<button type="button" class="btn btn-link btn-xs">No Thanks</button>
+					<div style="margin: 10px 0;">
+						<button class="btn btn-primary btn-xs" type="button">Sign Up</button>
+						<button class="btn btn-link btn-xs" type="button">No Thanks</button>
 					</div>
 				</div>
 			</div>
@@ -514,10 +512,9 @@ section: Extending Components
             <h4>Travel to Space by Balloon</h4>
             <p>Space Program LLC is offering balloon rides to space!</p>
         </div>
-        <div class="link-group">
-            <hr class="divider" />
-            <button type="button" class="btn btn-primary btn-xs">Sign Up</button>
-            <button type="button" class="btn btn-link btn-xs">No Thanks</button>
+        <div style="margin: 10px 0;">
+            <button class="btn btn-primary btn-xs" type="button">Sign Up</button>
+            <button class="btn btn-link btn-xs" type="button">No Thanks</button>
         </div>
     </div>
 </div>```</code></pre>

--- a/src/content/toggles.html
+++ b/src/content/toggles.html
@@ -482,7 +482,7 @@ section: Components
 
 							<p>Space Program LLC is offering balloon rides to space!</p>
 
-							<div class="link-group">
+							<div>
 								<hr class="divider">
 								<button type="button" class="btn btn-primary btn-xs">Sign Up</button>
 								<button type="button" class="btn btn-link btn-xs">No Thanks</button>

--- a/src/content/typography.html
+++ b/src/content/typography.html
@@ -136,38 +136,6 @@ navIndex: 0
 		</div>
 	</div>
 
-	<div class="row">
-		<div class="col-md-12">
-			<h3>Link Group</h3>
-			<blockquote class="blockquote-sm blockquote-success">
-				<p>Wrap <code>.link-group</code> around a group of anchor tags to increase the click area and spacing.</p>
-			</blockquote>
-			<div class="link-group">
-				<a href="#1">Link #1</a>
-				<a href="#1">Link #2</a>
-				<a href="#1">Link #3</a>
-				<a href="#1">Link #4</a>
-				<a href="#1">Link #5</a>
-				<a href="#1">Link #6</a>
-			</div>
-
-<div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse4"><span class="icon-caret-down"></span></a>
-</div>
-<div class="collapse" id="codeCollapse4">
-	<pre><code class="html">```<div class="link-group">
-    <a href="#">Link #1</a>
-    <a href="#">Link #2</a>
-    <a href="#">Link #3</a>
-    <a href="#">Link #4</a>
-    <a href="#">Link #5</a>
-    <a href="#">Link #6</a>
-</div>```</code></pre>
-</div>
-
-		</div>
-	</div>
-
 	<div class="row row-spacing">
 		<div class="col-md-12">
 			<h3>Contextual Texts</h3>

--- a/src/scss/lexicon-base/_type.scss
+++ b/src/scss/lexicon-base/_type.scss
@@ -61,25 +61,6 @@ body {
 
 @include bg-variant('.bg-default', $gray-lighter);
 
-// Anchor Tags
-
-.link-group {
-	margin: 10px 0;
-
-	a {
-		line-height: 2em;
-		padding: 0.25em;
-
-		&:first-child {
-			margin-left: 0;
-		}
-
-		&.btn {
-			line-height: normal;
-		}
-	}
-}
-
 // Marked Text
 
 mark,


### PR DESCRIPTION
Rebased.
Breaking: Removing http://liferay.github.io/lexicon/content/typography/#link-group, I don't think this was used in portal, but just in case.