### PR TITLE
Update: Fixes #81 add support for placing text around toggle-switch

### DIFF
--- a/src/content/toggles.html
+++ b/src/content/toggles.html
@@ -45,6 +45,8 @@ section: Components
 
 <div class="row">
 	<div class="col-md-12">
+		<h3>Toggle Switch with Data Attributes</h3>
+
 		<blockquote class="blockquote-sm blockquote-success" style="margin-top:15px;">
 			<p>Use data attributes <code>data-label-on=""</code> and <code>data-label-off=""</code> on <code>```<span class="toggle-switch-handle"></span>```</code> to display specific text when the switch is on and off.</p>
 		</blockquote>
@@ -53,7 +55,7 @@ section: Components
 			<div class="form-group">
 				<label>
 					<input class="toggle-switch" type="checkbox">
-					Toggle Switch with data-label-on
+					<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
 
 					<span aria-hidden="true" class="toggle-switch-bar">
 						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
@@ -68,7 +70,7 @@ section: Components
 	<pre><code>```<div class="form-group">
     <label>
         <input class="toggle-switch" type="checkbox">
-        Toggle Switch with data-label-on
+        <span class="toggle-switch-label">Toggle Switch with data-label-on</span>
 
         <span aria-hidden="true" class="toggle-switch-bar">
             <span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
@@ -89,7 +91,7 @@ section: Components
 			<div class="form-group">
 				<label>
 					<input class="toggle-switch" type="checkbox">
-					Toggle Switch with data-label on and data-label-off
+					<span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
 
 					<span aria-hidden="true" class="toggle-switch-bar">
 						<span class="toggle-switch-handle" data-label-off="Switch is off." data-label-on="Switch is on.">
@@ -104,7 +106,7 @@ section: Components
 	<pre><code>```<div class="form-group">
     <label>
         <input class="toggle-switch" type="checkbox">
-        Toggle Switch with data-label on and data-label-off
+        <span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
 
         <span aria-hidden="true" class="toggle-switch-bar">
             <span class="toggle-switch-handle" data-label-off="Switch is off." data-label-on="Switch is on.">
@@ -114,6 +116,94 @@ section: Components
 </div>```</code></pre>
 </div>
 
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="row row-spacing">
+	<div class="col-md-12">
+		<h3>Toggle Switch Text</h3>
+
+		<blockquote class="blockquote-sm blockquote-success">
+			<p>Add additional text with class <code>toggle-switch-text</code>.</p>
+		</blockquote>
+
+		<form action="#" method="get">
+			<div class="form-group">
+				<label>
+					<input class="toggle-switch" type="checkbox">
+					<span class="toggle-switch-label">Adding Required Text</span>
+
+					<span class="toggle-switch-text">Required *</span>
+
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+						</span>
+					</span>
+				</label>
+			</div>
+
+			<div class="form-group">
+				<label>
+					<input class="toggle-switch" type="checkbox">
+					<span class="toggle-switch-label">Adding Required Text</span>
+
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+						</span>
+					</span>
+
+					<span class="toggle-switch-text">Required *</span>
+				</label>
+			</div>
+
+			<div class="form-group">
+				<label>
+					<input class="toggle-switch" type="checkbox">
+					<span class="toggle-switch-label">Required Text on Right</span>
+
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+						</span>
+					</span>
+
+					<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
+				</label>
+			</div>
+
+			<div class="form-group">
+				<label>
+					<input class="toggle-switch" type="checkbox">
+					<span class="toggle-switch-label">Required Text on Left</span>
+
+					<span class="toggle-switch-text toggle-switch-text-left">Required *</span>
+
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
+						</span>
+					</span>
+				</label>
+			</div>
+
+			<div>
+				<label>
+					<input class="toggle-switch" type="checkbox">
+					<span class="toggle-switch-label">The Kitchen Sink</span>
+
+					<span class="toggle-switch-text">Top Text</span>
+
+					<span class="toggle-switch-text toggle-switch-text-left">Error</span>
+
+					<span aria-hidden="true" class="toggle-switch-bar">
+						<span class="toggle-switch-handle" data-label-off="OFF" data-label-on="ON">
+						</span>
+					</span>
+
+					<span class="toggle-switch-text toggle-switch-text-right">Required *</span>
+
+					<span class="toggle-switch-text">Bottom Text</span>
+				</label>
 			</div>
 		</form>
 	</div>
@@ -148,7 +238,7 @@ section: Components
 			<div class="form-group">
 				<label>
 					<input class="toggle-switch" type="checkbox">
-					Toggle Switch with data-label-on
+					<span class="toggle-switch-label">Toggle Switch with data-label-on</span>
 
 					<span aria-hidden="true" class="toggle-switch-bar">
 						<span class="toggle-switch-handle" data-label-off="" data-label-on="ON">
@@ -162,7 +252,7 @@ section: Components
 			<div class="form-group">
 				<label>
 					<input class="toggle-switch" type="checkbox">
-					Toggle Switch with data-label on and data-label-off
+					<span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
 
 					<span aria-hidden="true" class="toggle-switch-bar">
 						<span class="toggle-switch-handle" data-label-off="Locked" data-label-on="Edit">
@@ -179,7 +269,7 @@ section: Components
 	<pre><code>```<div class="form-group">
     <label>
         <input class="toggle-switch" type="checkbox">
-        Toggle Switch with data-label on and data-label-off
+        <span class="toggle-switch-label">Toggle Switch with data-label on and data-label-off</span>
 
         <span aria-hidden="true" class="toggle-switch-bar">
             <span class="toggle-switch-handle" data-label-off="Locked" data-label-on="Edit">

--- a/src/scss/atlas-theme/_toggle-switch.scss
+++ b/src/scss/atlas-theme/_toggle-switch.scss
@@ -58,4 +58,9 @@
 			}
 		}
 	}
+
+	.toggle-switch-text-left,
+	.toggle-switch-text-right {
+		line-height: $toggle-switch-bar-desktop-height;
+	}
 }

--- a/src/scss/lexicon-base/_toggle-switch.scss
+++ b/src/scss/lexicon-base/_toggle-switch.scss
@@ -32,6 +32,7 @@ input.toggle-switch {
 	&:empty ~ .toggle-switch-bar {
 		cursor: pointer;
 		display: block;
+		float: left;
 		font-size: 1.2rem;
 		line-height: $toggle-switch-bar-height;
 		min-height: $toggle-switch-bar-height;
@@ -146,4 +147,30 @@ input.toggle-switch {
 			@include transition(all 100ms ease-in);
 		}
 	}
+}
+
+.toggle-switch-label {
+	display: block;
+	margin-bottom: 2px;
+}
+
+.toggle-switch-text {
+	clear: both;
+	display: block;
+	font-size: 1.25rem;
+}
+
+.toggle-switch-text-left,
+.toggle-switch-text-right {
+	float: left;
+	line-height: $toggle-switch-bar-height;
+}
+
+.toggle-switch-text-left {
+	margin-right: 7px;
+}
+
+.toggle-switch-text-right {
+	clear: none;
+	margin-left: 7px;
 }


### PR DESCRIPTION
Resending because it was sent it against the wrong branch.

http://liferay.github.io/lexicon/content/toggles/

I ended up putting .toggle-switch-text outside of .toggle-switch-bar. This allows us to place text on every side of the switch.