### PR TITLE
Update: Fixes #82 Atlas checkboxes and radio buttons to be bigger

### DIFF
--- a/src/scss/atlas-theme/_forms.scss
+++ b/src/scss/atlas-theme/_forms.scss
@@ -131,6 +131,28 @@ select[disabled].form-control > option {
 .radio {
 	label {
 		font-weight: 500;
+		padding-left: 25px;
+
+		@media screen and (-webkit-min-device-pixel-ratio: 0) {
+			padding-left: 20px;
+		}
+	}
+}
+
+.checkbox input[type="checkbox"],
+.checkbox-inline input[type="checkbox"],
+.radio input[type="radio"],
+.radio-inline input[type="radio"] {
+	height: 20px;
+	margin-left: -25px;
+	margin-top: 0;
+	width: 20px;
+
+	@media screen and (-webkit-min-device-pixel-ratio: 0) {
+		height: 15px;
+		margin-left: -20px;
+		margin-top: 3px;
+		width: 14px;
 	}
 }
 


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/form-elements/#checkboxes-and-radios-no-extra-mark-up

Increase size of radio buttons and checkboxes to 20px in IE and FF. Chrome and Safari are 15px.