### PR TITLE
Fix: Mis-aligned checkboxes in checkbox-card and toggle-card-dm

### DIFF
--- a/src/scss/atlas-theme/_forms.scss
+++ b/src/scss/atlas-theme/_forms.scss
@@ -157,6 +157,18 @@ select[disabled].form-control > option {
 	}
 }
 
+.checkbox-card,
+.toggle-card-dm {
+	label {
+		padding-left: 0;
+	}
+
+	input[type="checkbox"],
+	input[type="radio"] {
+		margin-left: 0;
+	}
+}
+
 // Form Control Feedback
 
 .form-control-feedback {


### PR DESCRIPTION
https://github.com/liferay/lexicon/commit/33c792c98d93b8709e8580f0dc1225a71221b598 broke checkbox alignment for .checkbox-card and .toggle-card-dm.

http://liferay.github.io/lexicon/content/extending-cards/#cards-with-background-image-that-fills-remaining-space