### PR TITLE
Update: Align components on the left and right side

### DIFF
--- a/src/content/example_assorted.html
+++ b/src/content/example_assorted.html
@@ -1,0 +1,1518 @@
+---
+title: Assorted
+section: Example Pages
+---
+
+<header class="header-toolbar header-toolbar-default">
+	<div class="toolbar-group">
+		<div class="toolbar-group-content">
+			<a class="sidenav-toggler" href="#1">
+				<svg class="icon-monospaced lexicon-icon">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#product-menu-closed" />
+				</svg>
+			</a>
+		</div>
+
+		<div class="toolbar-group-content">
+			<a href="#">
+				<svg class="icon-monospaced lexicon-icon">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#angle-left" />
+				</svg>
+			</a>
+		</div>
+	</div>
+
+	<div class="toolbar-group-right">
+		<div class="toolbar-group-content">
+			<div class="dropdown">
+				<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</a>
+				<ul class="dropdown-menu dropdown-menu-right">
+					<li><a href="#1">Export</a></li>
+					<li><a href="#1">Import</a></li>
+					<li><a href="#1">Configuration</a></li>
+				</ul>
+			</div>
+		</div>
+	</div>
+
+	<div class="toolbar-group-expand-text">
+		<span title="Con panna plunger pot, café au lait barista so cream so affogato qui whipped. That doppio espresso, aromatic foam crema decaffeinated caramelization. Caramelization coffee, aged arabica sugar, so, half and half, grounds cultivar trifecta aroma chicory. Aromatic crema, cinnamon redeye cortado strong aftertaste sugar java.">Con panna plunger pot, café au lait barista so cream so affogato qui whipped. That doppio espresso, aromatic foam crema decaffeinated caramelization. Caramelization coffee, aged arabica sugar, so, half and half, grounds cultivar trifecta aroma chicory. Aromatic crema, cinnamon redeye cortado strong aftertaste sugar java.</span>
+	</div>
+</header>
+
+<nav class="navbar navbar-default">
+	<div class="navbar-header navbar-header-left-xs">
+		<a class="navbar-brand" href="#">Brand</a>
+	</div>
+
+	<div class="navbar-header navbar-header-right">
+		<button aria-expanded="false" class="collapsed navbar-toggle" data-target="#navbar-collapse-2" data-toggle="collapse" type="button">
+			<span class="sr-only">Toggle navigation</span>
+			<svg aria-hidden="true" class="lexicon-icon">
+				<use xlink:href="{{rootPath}}/images/icons/icons.svg#bars" />
+			</svg>
+		</button>
+	</div>
+
+	<div aria-expanded="false" class="collapse navbar-collapse" id="navbar-collapse-2">
+		<ul class="nav navbar-nav">
+			<li class="active"><a href="#">Link <span class="sr-only">(current)</span></a></li>
+			<li><a href="#">Link</a></li>
+			<li class="dropdown">
+				<a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">Dropdown <span class="caret"></span></a>
+				<ul class="dropdown-menu" role="menu">
+					<li><a href="#">Action</a></li>
+					<li><a href="#">Another action</a></li>
+					<li><a href="#">Something else here</a></li>
+					<li class="divider"></li>
+					<li><a href="#">Separated link</a></li>
+					<li class="divider"></li>
+					<li><a href="#">One more separated link</a></li>
+				</ul>
+			</li>
+		</ul>
+		<ul class="nav navbar-nav navbar-right">
+			<li><a href="#">Link</a></li>
+			<li class="dropdown">
+				<a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">Dropdown <span class="caret"></span></a>
+				<ul class="dropdown-menu" role="menu">
+					<li><a href="#">Action</a></li>
+					<li><a href="#">Another action</a></li>
+					<li><a href="#">Something else here</a></li>
+					<li class="divider"></li>
+					<li><a href="#">Separated link</a></li>
+				</ul>
+			</li>
+		</ul>
+		<form class="basic-search basic-search-autofit input-group navbar-form">
+			<div class="input-group-input">
+				<input class="form-control" placeholder=" Search..." type="text" />
+			</div>
+
+			<div class="input-group-btn">
+				<button class="btn btn-default" type="submit">
+					<svg class="lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+					</svg>
+				</button>
+			</div>
+		</form>
+	</div>
+</nav>
+
+<nav class="collapse-basic-search navbar navbar-default">
+	<div class="navbar-header visible-xs">
+		<button class="collapsed navbar-toggle navbar-toggle-left navbar-toggle-page-name" data-target="#navbar-collapse-001" data-toggle="collapse" type="button">
+			<span class="sr-only">Toggle Navigation</span>
+			<span class="page-name">Message Boards</span><!-- current page name goes here e.g. Message Boards Home -->
+			<span class="caret"></span>
+		</button>
+	</div>
+
+	<div class="collapse navbar-collapse navbar-collapse-left" id="navbar-collapse-001">
+		<ul class="nav navbar-nav">
+			<li class="active"><a href="#">Message Boards</a></li>
+			<li class="dropdown">
+				<a class="dropdown-toggle" data-toggle="dropdown" href="#">Dropdown <span class="caret"></span></a>
+				<ul aria-labelledby="dropdownMenu" class="dropdown-menu">
+					<li class="dropdown-header" role="presentation">Dropdown Header</li>
+					<li role="presentation">
+						<ul class="inline-scroller">
+							<li><a href="#">Actions</a></li>
+							<li><a href="#">Edit</a></li>
+							<li><a href="#">View</a></li>
+							<li><a href="#">Permissions</a></li>
+							<li><a href="#">Actions</a></li>
+							<li><a href="#">Edit</a></li>
+							<li><a href="#">View</a></li>
+							<li><a href="#">Permissions</a></li>
+							<li><a href="#">Actions</a></li>
+							<li><a href="#">Edit</a></li>
+							<li><a href="#">View</a></li>
+							<li><a href="#">Permissions</a></li>
+							<li><a href="#">Actions</a></li>
+							<li><a href="#">Edit</a></li>
+							<li><a href="#">View</a></li>
+							<li><a href="#">Permissions</a></li>
+						</ul>
+					</li>
+					<li class="disabled" role="presentation"><a href="#" role="menuitem">Disabled</a></li>
+					<li class="divider" role="presentation"></li>
+					<li role="presentation"><a href="#" role="menuitem">Scope</a></li>
+				</ul>
+			</li>
+
+			<li><a href="#">Link</a></li>
+			<li class="disabled"><a href="#">Disabled</a></li>
+		</ul>
+	</div>
+
+	<div class="navbar-header navbar-header-right">
+		<form action="../navbar" class="basic-search input-group" method="GET">
+			<div class="input-group-input">
+				<div class="basic-search-slider">
+					<button class="basic-search-close btn btn-default" type="button">
+						<svg class="lexicon-icon">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+						</svg>
+					</button>
+					<input class="form-control" name="search" placeholder=" Search..." type="text" />
+				</div>
+			</div>
+			<div class="input-group-btn">
+				<button class="btn btn-default" type="submit">
+					<svg class="lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+					</svg>
+				</button>
+			</div>
+		</form>
+	</div>
+</nav>
+
+<nav class="collapse-basic-search navbar navbar-default navbar-no-collapse">
+	<ul class="nav navbar-nav">
+		<li class="active"><a href="#">Message Boards</a></li>
+		<li class="dropdown">
+			<a class="dropdown-toggle" data-toggle="dropdown" href="#">Blogs <span class="caret"></span></a>
+			<ul aria-labelledby="dropdownMenu" class="dropdown-menu">
+				<li class="dropdown-header" role="presentation">Dropdown Header</li>
+				<li role="presentation">
+					<ul class="inline-scroller">
+						<li><a href="#">Actions</a></li>
+						<li><a href="#">Edit</a></li>
+						<li><a href="#">View</a></li>
+						<li><a href="#">Permissions</a></li>
+						<li><a href="#">Actions</a></li>
+						<li><a href="#">Edit</a></li>
+						<li><a href="#">View</a></li>
+						<li><a href="#">Permissions</a></li>
+						<li><a href="#">Actions</a></li>
+						<li><a href="#">Edit</a></li>
+						<li><a href="#">View</a></li>
+						<li><a href="#">Permissions</a></li>
+						<li><a href="#">Actions</a></li>
+						<li><a href="#">Edit</a></li>
+						<li><a href="#">View</a></li>
+						<li><a href="#">Permissions</a></li>
+					</ul>
+				</li>
+				<li class="disabled" role="presentation"><a href="#" role="menuitem">Disabled</a></li>
+				<li class="divider" role="presentation"></li>
+				<li role="presentation"><a href="#" role="menuitem">Scope</a></li>
+			</ul>
+		</li>
+	</ul>
+
+	<form class="basic-search input-group">
+		<div class="input-group-input">
+			<div class="basic-search-slider">
+				<button class="basic-search-close btn btn-default" type="button">
+					<svg class="lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+					</svg>
+				</button>
+				<input class="form-control" placeholder=" Search..." type="text" />
+			</div>
+		</div>
+		<div class="input-group-btn">
+			<button class="btn btn-default" type="submit">
+				<svg class="lexicon-icon">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#search" />
+				</svg>
+			</button>
+		</div>
+	</form>
+</nav>
+
+<div class="management-bar management-bar-default">
+	<div class="management-bar-header">
+		<div class="checkbox">
+			<label>
+				<input type="checkbox" value="">
+			</label>
+		</div>
+
+		<a class="management-bar-toggle management-bar-toggle-link collapsed" data-toggle="collapse" href="#mgmtBarCollapse0">
+			<span class="management-bar-item-title">Label</span>
+			<svg class="lexicon-icon">
+				<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-double-l" />
+			</svg>
+		</a>
+	</div>
+
+	<div class="collapse management-bar-collapse" id="mgmtBarCollapse0">
+		<ul class="nav management-bar-nav">
+			<li class="dropdown">
+				<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+					<span class="management-bar-item-title">Status: Approved, Draft, Pending, Expired</span>
+					<svg class="lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-double-l" />
+					</svg>
+				</a>
+				<ul class="dropdown-menu">
+					<li>
+						<form>
+							<div class="form-group">
+								<select class="form-control">
+									<option>1</option>
+									<option>2</option>
+									<option>3</option>
+									<option>4</option>
+									<option>5</option>
+								</select>
+							</div>
+							<div class="form-group">
+								<label for="exampleInputEmail3">Email address</label>
+								<input type="email" class="form-control" id="exampleInputEmail3" placeholder="Email">
+							</div>
+							<div class="checkbox checkbox-default active">
+								<label>
+									<input checked type="checkbox" value=""> Approved
+								</label>
+							</div>
+							<div class="checkbox checkbox-default active">
+								<label>
+									<input checked type="checkbox" value=""> Draft
+								</label>
+							</div>
+							<div class="checkbox checkbox-default active">
+								<label>
+									<input checked type="checkbox" value=""> Pending
+								</label>
+							</div>
+							<div class="checkbox checkbox-default active">
+								<label>
+									<input checked type="checkbox" value=""> Expired
+								</label>
+							</div>
+							<div class="checkbox checkbox-default">
+								<label>
+									<input type="checkbox" value=""> Scheduled
+								</label>
+							</div>
+							<div class="checkbox checkbox-default">
+								<label>
+									<input type="checkbox" value=""> Rejected
+								</label>
+							</div>
+						</form>
+					</li>
+					<li><a href="#1">Something Outside</a></li>
+				</ul>
+			</li>
+			<li class="dropdown">
+				<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+					<span class="management-bar-item-title">Recent</span>
+					<svg class="lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-double-l" />
+					</svg>
+				</a>
+				<ul class="dropdown-menu">
+					<li><a href="#1">All</a></li>
+					<li class="active"><a href="#1">Recent</a></li>
+					<li><a href="#1">Mine</a></li>
+				</ul>
+			</li>
+			<li class="dropdown">
+				<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+					<span class="management-bar-item-title">Order By: Modified Date</span>
+					<svg class="lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#caret-double-l" />
+					</svg>
+				</a>
+				<ul class="dropdown-menu">
+					<li><a href="#1">Name</a></li>
+					<li><a href="#1">Create Date</a></li>
+					<li class="active"><a href="#1">Modified Date</a></li>
+					<li><a href="#1">Downloads</a></li>
+					<li><a href="#1">Size</a></li>
+				</ul>
+			</li>
+			<li>
+				<a class="btn btn-default hidden-xs" href="#1"><span class="icon-caret-up icon-monospaced"></span></a>
+			</li>
+			<li>
+				<a class="btn btn-default hidden-xs" href="#1"><span class="icon-caret-down icon-monospaced"></span></a>
+			</li>
+		</ul>
+	</div>
+
+	<div class="management-bar-header-right">
+		<a class="btn btn-default" href="#">
+			<svg class="icon-monospaced lexicon-icon">
+				<use xlink:href="{{rootPath}}/images/icons/icons.svg#cards2" />
+			</svg>
+		</a>
+		<a class="btn btn-default" href="#">
+			<svg class="icon-monospaced lexicon-icon">
+				<use xlink:href="{{rootPath}}/images/icons/icons.svg#list" />
+			</svg>
+		</a>
+		<a class="btn btn-default hidden-xs" href="#">
+			<svg class="icon-monospaced lexicon-icon">
+				<use xlink:href="{{rootPath}}/images/icons/icons.svg#table2" />
+			</svg>
+		</a>
+	</div>
+</div>
+
+<div class="management-bar management-bar-default management-bar-no-collapse">
+	<ul class="nav management-bar-nav">
+		<li>
+			<div class="checkbox">
+				<label>
+					<input type="checkbox" value="">
+				</label>
+			</div>
+		</li>
+		<li>
+			<span class="management-bar-text">4 items selected</span>
+		</li>
+	</ul>
+
+	<ul class="nav management-bar-nav management-bar-nav-right">
+		<li>
+			<a class="btn btn-default" href="#">
+				<svg class="icon-monospaced lexicon-icon">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#trash" />
+				</svg>
+			</a>
+		</li>
+		<li class="dropdown">
+			<a aria-expanded="false" class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#" role="button">
+				<svg class="icon-monospaced lexicon-icon">
+					<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+				</svg>
+			</a>
+			<ul class="dropdown-menu dropdown-menu-right" role="menu">
+				<li><a href="#">Action</a></li>
+				<li><a href="#">Another action</a></li>
+				<li><a href="#">Something else here</a></li>
+				<li class="divider"></li>
+				<li><a href="#">Separated link</a></li>
+			</ul>
+		</li>
+	</ul>
+</div>
+
+<ul class="breadcrumb">
+	<li><a href="#" title="Home">Home</a></li>
+	<li><a href="#" title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</a></li>
+	<li class="active"><span title="Data">Data</span></li>
+</ul>
+
+<ul class="nav nav-pills">
+	<li class="active"><a href="#1">Fields</a></li>
+
+	<li><a href="#1">Settings</a></li>
+
+	<li class="disabled"><a href="#">Documents</a></li>
+
+	<li class="dropdown">
+		<a class="dropdown-toggle" data-toggle="dropdown" href="#1">Configuration <span class="caret"></span></a>
+
+		<ul class="dropdown-menu">
+			<li><a href="#1">Setup</a></li>
+			<li><a href="#1">Supported Clients</a></li>
+			<li><a href="#1">Permissions</a></li>
+			<li><a href="#1">Sharing</a></li>
+			<li class="divider"></li>
+			<li><a href="#1">Scope</a></li>
+		</ul>
+	</li>
+</ul>
+
+<ul class="nav nav-tabs" role="tablist">
+	<li class="active" role="presentation"><a aria-controls="fields" href="#fields" data-toggle="tab" role="tab">Fields</a></li>
+	<li role="presentation"><a aria-controls="settings" href="#settings" data-toggle="tab" role="tab">Settings</a></li>
+	<li class="disabled" role="presentation"><a href="#documents">Documents</a></li>
+	<li class="dropdown" role="presentation">
+		<a class="dropdown-toggle" data-toggle="dropdown" href="#configuration">Configuration <span class="caret"></span></a>
+		<ul class="dropdown-menu">
+			<li><a href="#1">Setup</a></li>
+			<li><a href="#1">Supported Clients</a></li>
+			<li><a href="#1">Permissions</a></li>
+			<li><a href="#1">Sharing</a></li>
+			<li class="divider"></li>
+			<li><a href="#1">Scope</a></li>
+		</ul>
+	</li>
+</ul>
+
+<table class="table table-list">
+	<thead>
+		<tr>
+			<th class="table-cell-field"></th>
+			<th class="table-cell-field hidden-xs hidden-sm">ID</th>
+			<th class="table-cell-content clamp-horizontal">
+				<div class="clamp-container">
+					<span class="truncate-text" title="Description">Title</span>
+				</div>
+			</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Status</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Modified Date</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Display Date</th>
+			<th class="table-cell-field">Author</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Type</th>
+			<th class="table-cell-field"></th>
+		</tr>
+	</thead>
+
+	<tbody>
+		<tr>
+			<td class="table-cell-field">
+				<div class="checkbox">
+					<label>
+						<input type="checkbox" value="">
+					</label>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">21146</td>
+			<td class="table-cell-content clamp-horizontal">
+				<div class="clamp-container">
+					<span class="truncate-text" title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</span>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field hidden-xs hidden-sm">2 Hours Ago</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field">Stanley Nelson</td>
+			<td class="table-cell-field hidden-xs hidden-sm">Folder</td>
+			<td class="table-cell-field">
+				<div class="dropdown">
+					<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+						<svg class="icon-monospaced lexicon-icon">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</a>
+					<ul class="dropdown-menu dropdown-menu-left-side">
+						<li><a href="#1">Download</a></li>
+						<li><a href="#1">Edit</a></li>
+						<li><a href="#1">Move</a></li>
+						<li><a href="#1">Checkout</a></li>
+						<li><a href="#1">Permissions</a></li>
+						<li><a href="#1">Move to Recycle Bin</a></li>
+					</ul>
+				</div>
+			</td>
+		</tr>
+		<tr class="active">
+			<td class="table-cell-field">
+				<div class="checkbox">
+					<label>
+						<input type="checkbox" value="">
+					</label>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">
+				21148
+			</td>
+			<td class="table-cell-content clamp-horizontal">
+				<div class="clamp-container">
+					<span class="truncate-text" title="Frappuccino medium americano">Frappuccino medium americano</span>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field hidden-xs hidden-sm">2 Hours Ago</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field">Stanley Nelson</td>
+			<td class="table-cell-field hidden-xs hidden-sm">Folder</td>
+			<td class="table-cell-field">
+				<div class="dropdown">
+					<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+						<svg class="icon-monospaced lexicon-icon">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</a>
+					<ul class="dropdown-menu dropdown-menu-left-side">
+						<li><a href="#1">Download</a></li>
+						<li><a href="#1">Edit</a></li>
+						<li><a href="#1">Move</a></li>
+						<li><a href="#1">Checkout</a></li>
+						<li><a href="#1">Permissions</a></li>
+						<li><a href="#1">Move to Recycle Bin</a></li>
+					</ul>
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<table class="table">
+	<thead>
+		<tr>
+			<th class="table-cell-field"></th>
+			<th class="table-cell-field hidden-xs hidden-sm">ID</th>
+			<th class="table-cell-content clamp-horizontal">
+				<div class="clamp-container">
+					<span class="truncate-text" title="Description">Title</span>
+				</div>
+			</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Status</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Modified Date</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Display Date</th>
+			<th class="table-cell-field">Author</th>
+			<th class="table-cell-field hidden-xs hidden-sm">Type</th>
+			<th class="table-cell-field"></th>
+		</tr>
+	</thead>
+
+	<tbody>
+		<tr>
+			<td class="table-cell-field">
+				<div class="checkbox">
+					<label>
+						<input type="checkbox" value="">
+					</label>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">21146</td>
+			<td class="table-cell-content clamp-horizontal">
+				<div class="clamp-container">
+					<span class="truncate-text" title="Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</span>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field hidden-xs hidden-sm">2 Hours Ago</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field">Stanley Nelson</td>
+			<td class="table-cell-field hidden-xs hidden-sm">Folder</td>
+			<td class="table-cell-field">
+				<div class="dropdown">
+					<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+						<svg class="icon-monospaced lexicon-icon">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</a>
+					<ul class="dropdown-menu dropdown-menu-left-side">
+						<li><a href="#1">Download</a></li>
+						<li><a href="#1">Edit</a></li>
+						<li><a href="#1">Move</a></li>
+						<li><a href="#1">Checkout</a></li>
+						<li><a href="#1">Permissions</a></li>
+						<li><a href="#1">Move to Recycle Bin</a></li>
+					</ul>
+				</div>
+			</td>
+		</tr>
+		<tr class="active">
+			<td class="table-cell-field">
+				<div class="checkbox">
+					<label>
+						<input type="checkbox" value="">
+					</label>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">
+				21148
+			</td>
+			<td class="table-cell-content clamp-horizontal">
+				<div class="clamp-container">
+					<span class="truncate-text" title="Frappuccino medium americano">Frappuccino medium americano</span>
+				</div>
+			</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field hidden-xs hidden-sm">2 Hours Ago</td>
+			<td class="table-cell-field hidden-xs hidden-sm">--</td>
+			<td class="table-cell-field">Stanley Nelson</td>
+			<td class="table-cell-field hidden-xs hidden-sm">Folder</td>
+			<td class="table-cell-field">
+				<div class="dropdown">
+					<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+						<svg class="icon-monospaced lexicon-icon">
+							<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+						</svg>
+					</a>
+					<ul class="dropdown-menu dropdown-menu-left-side">
+						<li><a href="#1">Download</a></li>
+						<li><a href="#1">Edit</a></li>
+						<li><a href="#1">Move</a></li>
+						<li><a href="#1">Checkout</a></li>
+						<li><a href="#1">Permissions</a></li>
+						<li><a href="#1">Move to Recycle Bin</a></li>
+					</ul>
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<ul class="row list-unstyled">
+	<li class="col-md-6">
+		<div class="checkbox checkbox-card checkbox-middle-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<svg class="icon-monospaced lexicon-icon">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</div>
+						<div class="card-col-content card-col-gutters clamp-horizontal">
+							<div class="clamp-container"><span class="h4 truncate-text" title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span></div>
+						</div>
+						<div class="card-col-field" style="vertical-align:top;">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-md-6">
+		<div class="checkbox checkbox-card checkbox-middle-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<svg class="icon-monospaced lexicon-icon">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</div>
+						<div class="card-col-content card-col-gutters clamp-horizontal">
+							<div class="clamp-container"><span class="h4 truncate-text" title="Folder 01">Folder 01</span></div>
+						</div>
+						<div class="card-col-field" style="vertical-align:top;">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-md-6">
+		<div class="checkbox checkbox-card checkbox-middle-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<svg class="icon-monospaced lexicon-icon">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</div>
+						<div class="card-col-content card-col-gutters clamp-horizontal">
+							<div class="clamp-container"><span class="h4 truncate-text" title="Folder 02">Folder 02</span></div>
+						</div>
+						<div class="card-col-field" style="vertical-align:top;">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-md-6">
+		<div class="checkbox checkbox-card checkbox-middle-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<svg class="icon-monospaced lexicon-icon">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+							</svg>
+						</div>
+						<div class="card-col-content card-col-gutters clamp-horizontal">
+							<div class="clamp-container"><span class="h4 truncate-text" title="Folder 03">Folder 03</span></div>
+						</div>
+						<div class="card-col-field" style="vertical-align:top;">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+</ul>
+
+<div class="row">
+	<div class="col-xs-6">
+		<div class="checkbox checkbox-card checkbox-middle-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<span class="icon-monospaced icon-folder-close-alt" style="width: 60px;height: 60px;line-height: 60px;background-color: #EEE;"></span>
+						</div>
+						<div class="card-col-content card-col-gutters clamp-horizontal">
+							<div class="clamp-container"><span class="truncate-text" title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span></div>
+						</div>
+						<div class="card-col-field" style="vertical-align:top;">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg aria-hidden="true" class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</div>
+
+	<div class="col-xs-6">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-padded">
+				<div class="card-col-field">
+					<img src="../../images/switch_on_icon.png">
+				</div>
+				<div class="card-col-field card-col-gutters">
+					<span class="icon-monospaced icon-folder-close-alt" style="width: 60px;height: 60px;line-height: 60px;background-color: #EEE;"></span>
+				</div>
+				<div class="card-col-content card-col-gutters clamp-horizontal">
+					<div class="clamp-container"><span class="truncate-text" title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span></div>
+				</div>
+				<div class="card-col-field" style="vertical-align:top;">
+					<div class="dropdown">
+						<a class="dropdown-toggle" data-toggle="dropdown" href="#1" aria-expanded="false">
+							<svg aria-hidden="true" class="icon-monospaced lexicon-icon">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+							</svg>
+						</a>
+						<ul class="dropdown-menu dropdown-menu-right">
+							<li><a href="#1">Download</a></li>
+							<li><a href="#1">Edit</a></li>
+							<li><a href="#1">Move</a></li>
+							<li><a href="#1">Checkout</a></li>
+							<li><a href="#1">Permissions</a></li>
+							<li><a href="#1">Move to Recycle Bin</a></li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<ul class="row list-unstyled" id="cardSection">
+	<li class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
+		<div class="checkbox toggle-card-dm">
+			<label>
+				<input type="checkbox" value="">
+				<div class="toggle-card-container card card-dm">
+					<div class="aspect-ratio">
+						<img alt="thumbnail" src="../../images/thumbnail_coffee.jpg">
+						<span class="sticker sticker-warning sticker-bottom">PNG</span>
+					</div>
+					<div class="card-footer">
+						<div class="dropdown card-dm-more-options">
+							<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+								<svg class="icon-monospaced lexicon-icon">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu dropdown-menu-right">
+								<li><a href="#1">Download</a></li>
+								<li><a href="#1">Edit</a></li>
+								<li><a href="#1">Move</a></li>
+								<li><a href="#1">Checkout</a></li>
+								<li><a href="#1">Permissions</a></li>
+								<li><a href="#1">Move to Recycle Bin</a></li>
+							</ul>
+						</div>
+						<div class="card-dm-details">
+							<div class="card-dm-text">Aldcott Gage George Polwarth-Kitchener</div>
+							<div class="card-dm-text-large" title="thumbnail_dock.jpg">thumbnail_dock.jpg</div>
+							<div class="card-dm-text-small">Approved</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
+		<div class="checkbox toggle-card-dm">
+			<label>
+				<input type="checkbox" value="">
+				<div class="toggle-card-container card card-dm">
+					<div class="aspect-ratio">
+						<img alt="thumbnail" src="../../images/thumbnail_coffee.jpg">
+						<span class="sticker sticker-default sticker-bottom">TXT</span>
+					</div>
+					<div class="card-footer">
+						<div class="dropdown card-dm-more-options">
+							<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+								<svg class="icon-monospaced lexicon-icon">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu dropdown-menu-right">
+								<li><a href="#1">Download</a></li>
+								<li><a href="#1">Edit</a></li>
+								<li><a href="#1">Move</a></li>
+								<li><a href="#1">Checkout</a></li>
+								<li><a href="#1">Permissions</a></li>
+								<li><a href="#1">Move to Recycle Bin</a></li>
+							</ul>
+						</div>
+						<div class="card-dm-details">
+							<div class="card-dm-text">Aldcott Gage George Polwarth-Kitchener</div>
+							<div class="card-dm-text-large" title="thumbnail_dock.jpg">thumbnail_dock.jpg</div>
+							<div class="card-dm-text-small">Approved</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
+		<div class="checkbox toggle-card-dm">
+			<label>
+				<input type="checkbox" value="">
+				<div class="toggle-card-container card card-dm">
+					<div class="aspect-ratio">
+						<img alt="thumbnail" src="../../images/thumbnail_coffee.jpg">
+						<span class="sticker sticker-danger sticker-bottom">PDF</span>
+					</div>
+					<div class="card-footer">
+						<div class="dropdown card-dm-more-options">
+							<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+								<svg aria-hidden="true" class="icon-monospaced lexicon-icon">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu dropdown-menu-right">
+								<li><a href="#1">Download</a></li>
+								<li><a href="#1">Edit</a></li>
+								<li><a href="#1">Move</a></li>
+								<li><a href="#1">Checkout</a></li>
+								<li><a href="#1">Permissions</a></li>
+								<li><a href="#1">Move to Recycle Bin</a></li>
+							</ul>
+						</div>
+						<div class="card-dm-details">
+							<div class="card-dm-text">Aldcott Gage George Polwarth-Kitchener</div>
+							<div class="card-dm-text-large" title="thumbnail_dock.jpg">thumbnail_dock.jpg</div>
+							<div class="card-dm-text-small">Approved</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
+		<div class="checkbox toggle-card-dm">
+			<label>
+				<input type="checkbox" value="">
+				<div class="toggle-card-container card card-dm">
+					<div class="aspect-ratio">
+						<img alt="thumbnail" src="../../images/thumbnail_coffee.jpg">
+						<span class="sticker sticker-info sticker-bottom">DOC</span>
+					</div>
+					<div class="card-footer">
+						<div class="dropdown card-dm-more-options">
+							<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+								<svg class="icon-monospaced lexicon-icon">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu dropdown-menu-right">
+								<li><a href="#1">Download</a></li>
+								<li><a href="#1">Edit</a></li>
+								<li><a href="#1">Move</a></li>
+								<li><a href="#1">Checkout</a></li>
+								<li><a href="#1">Permissions</a></li>
+								<li><a href="#1">Move to Recycle Bin</a></li>
+							</ul>
+						</div>
+						<div class="card-dm-details">
+							<div class="card-dm-text">Aldcott Gage George Polwarth-Kitchener</div>
+							<div class="card-dm-text-large" title="thumbnail_dock.jpg">thumbnail_dock.jpg</div>
+							<div class="card-dm-text-small">Approved</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
+		<div class="checkbox toggle-card-dm">
+			<label>
+				<input type="checkbox" value="">
+				<div class="toggle-card-container card card-dm">
+					<div class="aspect-ratio">
+						<img alt="thumbnail" src="../../images/thumbnail_coffee.jpg">
+						<span class="sticker sticker-success sticker-bottom">XLS</span>
+					</div>
+					<div class="card-footer">
+						<div class="dropdown card-dm-more-options">
+							<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+								<svg aria-hidden="true" class="icon-monospaced lexicon-icon">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu dropdown-menu-right">
+								<li><a href="#1">Download</a></li>
+								<li><a href="#1">Edit</a></li>
+								<li><a href="#1">Move</a></li>
+								<li><a href="#1">Checkout</a></li>
+								<li><a href="#1">Permissions</a></li>
+								<li><a href="#1">Move to Recycle Bin</a></li>
+							</ul>
+						</div>
+						<div class="card-dm-details">
+							<div class="card-dm-text">Aldcott Gage George Polwarth-Kitchener</div>
+							<div class="card-dm-text-large" title="thumbnail_dock.jpg">thumbnail_dock.jpg</div>
+							<div class="card-dm-text-small">Approved</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+
+	<li class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
+		<div class="checkbox toggle-card-dm">
+			<label>
+				<input type="checkbox" value="">
+				<div class="toggle-card-container card card-dm">
+					<div class="aspect-ratio">
+						<img alt="thumbnail" src="../../images/thumbnail_coffee.jpg">
+						<span class="sticker sticker-warning sticker-bottom">PNG</span>
+					</div>
+					<div class="card-footer">
+						<div class="dropdown card-dm-more-options">
+							<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+								<svg class="icon-monospaced lexicon-icon">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+								</svg>
+							</a>
+							<ul class="dropdown-menu dropdown-menu-right">
+								<li><a href="#1">Download</a></li>
+								<li><a href="#1">Edit</a></li>
+								<li><a href="#1">Move</a></li>
+								<li><a href="#1">Checkout</a></li>
+								<li><a href="#1">Permissions</a></li>
+								<li><a href="#1">Move to Recycle Bin</a></li>
+							</ul>
+						</div>
+						<div class="card-dm-details">
+							<div class="card-dm-text">Aldcott Gage George Polwarth-Kitchener</div>
+							<div class="card-dm-text-large" title="thumbnail_dock.jpg">thumbnail_dock.jpg</div>
+							<div class="card-dm-text-small">Approved</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+</ul>
+
+<div class="list-group">
+	<a aria-expanded="false" class="collapsed list-group-heading" data-toggle="collapse" href="#tabularListGroupCollapse1">List Group Heading</a>
+	<div class="collapse" id="tabularListGroupCollapse1">
+		<ul class="tabular-list-group">
+			<li class="list-group-item">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Larry Bird the best power forward in Celtic's history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<h6 class="text-default">
+						<span>5 Folders</span>
+						<span>4 Entries</span>
+					</h6>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+
+			<li class="list-group-item">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Karl Malone the best power forward in Jazz history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<h6 class="text-default">
+						<span>5 Folders</span>
+						<span>4 Entries</span>
+					</h6>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+		</ul>
+	</div>
+
+	<a aria-expanded="true" class="list-group-heading" data-toggle="collapse" href="#tabularListGroupCollapse2">List Group Heading</a>
+	<div class="collapse in" id="tabularListGroupCollapse2">
+		<ul class="tabular-list-group">
+			<li class="list-group-item">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Larry Bird the best power forward in Celtic's history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<h6 class="text-default">
+						<span>5 Folders</span>
+						<span>4 Entries</span>
+					</h6>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+
+			<li class="list-group-item">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Karl Malone the best power forward in Jazz history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<h6 class="text-default">
+						<span>5 Folders</span>
+						<span>4 Entries</span>
+					</h6>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+		</ul>
+	</div>
+
+	<a aria-expanded="false" class="collapsed list-group-heading" data-toggle="collapse" href="#tabularListGroupCollapse3">List Group Heading</a>
+	<div class="collapse" id="tabularListGroupCollapse3">
+		<ul class="tabular-list-group">
+			<li class="list-group-item list-group-item-success">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Larry Bird the best power forward in Celtic's history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<div class="status">Approved</div>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+
+			<li class="list-group-item list-group-item-warning">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Karl Malone the best power forward in Jazz history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<div class="status">Pending</div>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+
+			<li class="list-group-item list-group-item-info">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Dennis Rodman the best power forward in Bulls history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<div class="status">Draft</div>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+
+			<li class="list-group-item list-group-item-default">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">LeBron James the best power forward in Heat history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<div class="status">Expired</div>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+
+			<li class="list-group-item list-group-item-primary">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Tim Duncan the best power forward in Spurs' history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<div class="status">Scheduled</div>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+
+			<li class="list-group-item list-group-item-danger">
+				<div class="list-group-item-field">
+					<input type="checkbox">
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+					</svg>
+				</div>
+
+				<div class="list-group-item-content">
+					<h5 class="text-primary">Kevin Garnett the best power forward in Pistons' history.</h5>
+					<h6 class="text-default">Monica Bellucci</h6>
+					<div class="status">Rejected</div>
+				</div>
+
+				<div class="list-group-item-field">
+					<svg class="icon-monospaced lexicon-icon">
+						<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+					</svg>
+				</div>
+			</li>
+		</ul>
+	</div>
+</div>
+
+<ul class="list-group list-group-card list-group-card-checkbox-hidden-xs">
+	<li class="list-group-heading">List Heading</li>
+	<li class="list-group-item">
+		<div class="checkbox checkbox-card checkbox-default checkbox-top-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<div class="list-group-card-icon">
+								<div class="user-icon user-icon-default">
+									<span>AC</span>
+								</div>
+							</div>
+						</div>
+						<div class="card-col-content card-col-gutters">
+							<h5 class="text-default" title="Alberto Calvo, modified 2 hours ago">Alberto Calvo, modified 2 hours ago</h5>
+							<h4 title="7 UX Trends of 2015: Get Ready for Big Changes">7 UX Trends of 2015: Get Ready for Big Changes</h4>
+							<h5 class="text-default" title="Approved">Approved</h5>
+						</div>
+						<div class="card-col-field">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+	<li class="list-group-item">
+		<div class="checkbox checkbox-card checkbox-default checkbox-top-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<div class="list-group-card-icon">
+								<div class="user-icon">
+									<img alt="thumbnail" class="img-responsive" src="../../images/thumbnail_coffee.jpg">
+								</div>
+							</div>
+						</div>
+						<div class="card-col-content card-col-gutters">
+							<h5 class="text-default" title="Cristina Pineiro, modified 2 hours ago">Cristina Pineiro, modified 2 hours ago</h5>
+							<h4 title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</h4>
+							<h5 class="text-default" title="Approved">Approved</h5>
+						</div>
+						<div class="card-col-field">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+	<li class="list-group-item">
+		<div class="checkbox checkbox-card checkbox-default checkbox-top-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<div class="list-group-card-icon">
+								<svg class="icon-monospaced lexicon-icon">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
+								</svg>
+							</div>
+						</div>
+						<div class="card-col-content card-col-gutters">
+							<h5 class="text-default" title="Susan Brown, modified 3 hours ago">Susan Brown, modified 3 hours ago</h5>
+							<h4 title="Getting Up to Speed">Getting Up to Speed</h4>
+							<h5 class="text-default" title="Approved">Approved</h5>
+						</div>
+						<div class="card-col-field">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+	<li class="list-group-item">
+		<div class="checkbox checkbox-card checkbox-default checkbox-top-left">
+			<label>
+				<input type="checkbox" value="">
+				<div class="card card-horizontal">
+					<div class="card-row card-row-padded">
+						<div class="card-col-field">
+							<div class="list-group-card-icon">
+								<div class="user-icon">
+									<img alt="thumbnail" class="img-responsive" src="../../images/thumbnail_coyote.jpg">
+								</div>
+							</div>
+						</div>
+						<div class="card-col-content card-col-gutters">
+							<h5 class="text-default" title="Sergio Ruiz, modified 9 hours ago">Sergio Ruiz, modified 9 hours ago</h5>
+							<h4 title="Introducing FS3">Introducing FS3</h4>
+							<h5 class="text-default" title="Approved">Approved</h5>
+						</div>
+						<div class="card-col-field">
+							<div class="dropdown">
+								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
+									<svg class="icon-monospaced lexicon-icon">
+										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
+									</svg>
+								</a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><a href="#1">Download</a></li>
+									<li><a href="#1">Edit</a></li>
+									<li><a href="#1">Move</a></li>
+									<li><a href="#1">Checkout</a></li>
+									<li><a href="#1">Permissions</a></li>
+									<li><a href="#1">Move to Recycle Bin</a></li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</label>
+		</div>
+	</li>
+</ul>
+
+<script>
+	$('.collapse-basic-search').collapsibleSearch();
+</script>

--- a/src/scss/atlas-theme/_breadcrumbs.scss
+++ b/src/scss/atlas-theme/_breadcrumbs.scss
@@ -1,6 +1,4 @@
 .breadcrumb {
-	padding-left: 0;
-
 	> li {
 		font-size: 12px;
 		font-weight: 500;

--- a/src/scss/atlas-theme/_management-bar.scss
+++ b/src/scss/atlas-theme/_management-bar.scss
@@ -47,7 +47,8 @@
 		> .checkbox,
 		> .radio {
 			@media screen and (min-width: $grid-float-breakpoint) {
-				padding: 20px 15px;
+				padding-bottom: 20px;
+				padding-top: 20px;
 			}
 		}
 	}

--- a/src/scss/atlas-theme/_navbar.scss
+++ b/src/scss/atlas-theme/_navbar.scss
@@ -330,7 +330,7 @@
 			border-width: 0;
 			color: $brand-default;
 			padding-left: 12px;
-			padding-right: 12px;
+			padding-right: 24px;
 
 			@media screen and (min-width: $grid-float-breakpoint) {
 				height: $navbar-default-desktop-height;

--- a/src/scss/atlas-theme/_toolbars.scss
+++ b/src/scss/atlas-theme/_toolbars.scss
@@ -2,12 +2,9 @@
 
 .header-toolbar {
 	font-size: 16px;
-	padding: 0 12px;
 
 	@media screen and (min-width: $grid-float-breakpoint) {
 		font-size: 19px;
-		padding-left: 24px;
-		padding-right: 24px;
 	}
 
 	.header-toolbar-title {
@@ -34,28 +31,6 @@
 			display: inline;
 			margin: 0;
 		}
-	}
-
-	.toolbar-group:first-child {
-		.toolbar-group-content,
-		.toolbar-group-field {
-			@media screen and (min-width: $grid-float-breakpoint) {
-				padding-left: 12px;
-			}
-
-			&:first-child {
-				padding-left: 0;
-				padding-right: 12px;
-
-				@media screen and (min-width: $grid-float-breakpoint) {
-					padding-right: 24px;
-				}
-			}
-		}
-	}
-
-	.toolbar-group-expand-text {
-		padding: 0 12px;
 	}
 }
 

--- a/src/scss/atlas-theme/variables/_navbar.scss
+++ b/src/scss/atlas-theme/variables/_navbar.scss
@@ -3,7 +3,7 @@
 // Basics of a navbar
 $navbar-height:                            48px !default;
 $navbar-link-line-height: 24px !default; // Atlas
-$navbar-padding-horizontal:                12px !default;
+$navbar-padding-horizontal:                15px !default;
 $navbar-padding-vertical:                  floor(($navbar-height - $navbar-link-line-height) / 2) !default;
 
 $navbar-desktop-height: 60px !default; // Atlas

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -17,7 +17,7 @@
 
 .card {
 	.card-row {
-		width: 100.4%; // Webkit rounding
+		width: 100%;
 	}
 
 	.figure {

--- a/src/scss/lexicon-base/_list-group.scss
+++ b/src/scss/lexicon-base/_list-group.scss
@@ -145,19 +145,19 @@ button.list-group-heading,
 		border-left-width: 0;
 		border-right-width: 0;
 		border-top-width: 0;
-		padding: 1em 0.3em;
+		padding: $table-cell-padding;
 		position: relative;
 		word-break: break-all; // IE
 		word-break: break-word;
 
 		&:first-child {
 			border-left-width: $tabular-list-group-border-width;
-			padding-left: 1em;
+			padding-left: 15px;
 		}
 
 		&:last-child {
 			border-right-width: $tabular-list-group-border-width;
-			padding-right: 1em;
+			padding-right: 15px;
 		}
 	}
 

--- a/src/scss/lexicon-base/_management-bar.scss
+++ b/src/scss/lexicon-base/_management-bar.scss
@@ -137,6 +137,8 @@
 	@media screen and (min-width: $grid-float-breakpoint) {
 		clear: none;
 		margin-top: 0;
+		padding-left: 0;
+		padding-right: 0;
 		position: static;
 	}
 }
@@ -152,12 +154,6 @@
 
 			&:first-child {
 				margin-left: 0;
-
-				> .checkbox,
-				> .radio {
-					padding-left: 0;
-					padding-right: 0;
-				}
 			}
 
 			> a {
@@ -182,13 +178,14 @@
 	@extend .navbar-nav;
 
 	> li {
-		> .checkbox,
-		.management-bar-text {
-			padding: $management-bar-padding-vertical $management-bar-padding-horizontal;
+		> .checkbox {
+			padding-bottom: $management-bar-padding-vertical;
+			padding-top: $management-bar-padding-vertical;
 		}
 
 		.management-bar-text {
 			display: inline-block;
+			padding: $management-bar-padding-vertical $management-bar-padding-horizontal;
 		}
 	}
 }

--- a/src/scss/lexicon-base/_tables.scss
+++ b/src/scss/lexicon-base/_tables.scss
@@ -1,3 +1,25 @@
+.table {
+	> thead,
+	> tbody,
+	> tfoot {
+		tr td {
+			&:first-child {
+				padding-left: 15px;
+
+				.checkbox {
+					margin-bottom: 0;
+					margin-left: 1px;
+					margin-top: 0;
+				}
+			}
+
+			&:last-child {
+				padding-right: 15px;
+			}
+		}
+	}
+}
+
 .table-cell-content {
 	position: relative;
 	word-break: break-all; // IE

--- a/src/scss/lexicon-base/_toolbars.scss
+++ b/src/scss/lexicon-base/_toolbars.scss
@@ -203,8 +203,32 @@
 		height: $header-toolbar-height;
 	}
 
+	.toolbar-group {
+		margin-right: $toolbar-group-padding-horizontal;
+		padding-right: 0;
+
+		&:first-child {
+			.toolbar-group-content,
+			.toolbar-group-field {
+				padding-left: $header-toolbar-padding-horizontal;
+
+				&:first-child {
+					padding-left: 0;
+					padding-right: $header-toolbar-padding-horizontal;
+				}
+			}
+		}
+	}
+
+	.toolbar-group-right {
+		margin-left: $toolbar-group-padding-horizontal;
+		padding-left: 0;
+	}
+
 	.toolbar-group-expand-text {
 		line-height: $header-toolbar-height;
+		margin-left: $toolbar-group-padding-horizontal; 
+		margin-right: $toolbar-group-padding-horizontal;
 	}
 
 	.toolbar-group-content {
@@ -220,6 +244,15 @@
 .header-toolbar-default {
 	background-color: $header-toolbar-default-bg;
 	border: $header-toolbar-default-border-width solid $header-toolbar-default-border;
+
+	.toolbar-group:first-child {
+		.toolbar-group-content,
+		.toolbar-group-field {
+			&:first-child {
+				border-right: $header-toolbar-default-border-width solid $header-toolbar-default-border;
+			}
+		}
+	}
 
 	.toolbar-group-content {
 		> a,

--- a/src/scss/lexicon-base/variables/_cards.scss
+++ b/src/scss/lexicon-base/variables/_cards.scss
@@ -1,6 +1,6 @@
 $card-border-width: 1px !default;
 $card-divider-height: 1px !default;
-$card-gutter-width: 10px !default;
+$card-gutter-width: 15px !default;
 $card-margin-bottom: $line-height-computed !default;
 
 // Skin


### PR DESCRIPTION
Created new demo: /lexicon/build/content/example-assorted/
Align checkboxes and buttons on left and right side for:
header-toolbar
navbar
management-bar
breadcrumbs
tabs
tables
cards
list-groups