### PR TITLE
Update card dropdown toggle color

### DIFF
--- a/src/scss/atlas-theme/_cards.scss
+++ b/src/scss/atlas-theme/_cards.scss
@@ -3,10 +3,7 @@
 	box-shadow: $card-box-shadow;
 
 	.dropdown-toggle {
-		&.icon-ellipsis-vertical,
-		.icon-ellipsis-vertical {
-			color: $dropdown-link-color;
-		}
+		color: $dropdown-link-color;
 	}
 }
 

--- a/src/scss/atlas-theme/_dropdowns.scss
+++ b/src/scss/atlas-theme/_dropdowns.scss
@@ -1,3 +1,12 @@
+.dropdown,
+.dropdown-toggle {
+	display: inline-block;
+}
+
+.dropdown .icon-monospaced {
+	margin: 2px;
+}
+
 .dropdown-header {
 	font-size: $dropdown-header-font-size;
 	overflow: hidden;


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/cards/#truncating-text-inside-horizontal-card-without-card-row-layout-fixed

Card vertical ellipsis dropdown link should be color 869cad
Arrows on dropdown menu should be centered to icon-monospaced