### PR TITLE
Update: Navbar and management-bar no collapse dropdowns should have background

### DIFF
--- a/src/scss/lexicon-base/_management-bar.scss
+++ b/src/scss/lexicon-base/_management-bar.scss
@@ -163,6 +163,7 @@
 		}
 
 		.dropdown-menu {
+			background-color: $dropdown-bg;
 			border: 1px solid $dropdown-border;
 			box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
 			position: absolute;

--- a/src/scss/lexicon-base/_navbar.scss
+++ b/src/scss/lexicon-base/_navbar.scss
@@ -351,6 +351,7 @@
 	}
 
 	.dropdown-menu {
+		background-color: $dropdown-bg;
 		border: 1px solid $dropdown-border;
 		box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
 		position: absolute;


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/navbar/#navbar-no-collapse

Content under dropdowns in mobile view on shows through dropdown, also happens on management-bar-no-collapse.