### PR TITLE
Update: Add destroy method

### DIFF
--- a/src/content/sidenav.html
+++ b/src/content/sidenav.html
@@ -73,7 +73,10 @@ section: Components (JS)
 		<div class="sidenav-container" id="mySidenavContainerId">
 			<div class="sidenav-menu-slider" style="background:#FFF;">
 				<div class="sidenav-menu">
-					<div class="col-md-12">... Your Side Nav Content ...</div>
+					<div class="col-md-12">
+						<a class="sidenav-close pull-right" href="#1">X</a>
+						<p>... Your Side Nav Content ...</p>
+					</div>
 				</div>
 			</div>
 
@@ -125,7 +128,10 @@ section: Components (JS)
 		<div class="sidenav-container" id="mySidenavContainerId1">
 			<div class="sidenav-menu-slider" style="background:#FFF;">
 				<div class="sidenav-menu">
-					<div class="col-md-12">... Your Side Nav Content ...</div>
+					<div class="col-md-12">
+						<a class="sidenav-close pull-right" href="#1">X</a>
+						<p>... Your Side Nav Content ...</p>
+					</div>
 				</div>
 			</div>
 

--- a/src/content/sidenav.html
+++ b/src/content/sidenav.html
@@ -426,8 +426,6 @@ sideNavInstance.hide().visible(); // returns false```</code></pre></p>
 		toggler: '#mySidenavToggleId1'
 	});
 
-	$('[data-toggle="sidenav"]').sideNavigation();
-
 	$('#showSimpleSidenav2').on('click', function(event) {
 		event.preventDefault();
 

--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -136,16 +136,8 @@
 
 			// Detach sidenav close
 
-			var closeButton = element.find('.sidenav-close').first();
-
-			if (instance.useDataAttribute) {
-				var simpleSidenav = instance._getSimpleSidenavNavigation();
-
-				closeButton = simpleSidenav.find('.sidenav-close').first();
-			}
-
-			closeButton.off('click.lexicon.sidenav');
-			closeButton.data('click.lexicon.sidenav', null);
+			doc.off('click.close.lexicon.sidenav', instance.closeButtonSelector);
+			doc.data(instance.dataCloseButtonSelector, null);
 
 			// Detach toggler
 
@@ -648,23 +640,34 @@
 			var instance = this;
 
 			var element = instance.element;
+			var options = instance.options;
 
-			var closeButton = element.find('.sidenav-close').first();
-			var container = instance.options.target ? $(instance.options.target) : doc.find(element.attr('href'));
+			var containerSelector = '#' + element.attr('id');
 
 			if (instance.useDataAttribute) {
-				closeButton = container.find('.sidenav-close');
+				containerSelector = options.target || element.attr('href');
 			}
 
-			if (!closeButton.data('click.lexicon.sidenav')) {
-				closeButton.on('click.lexicon.sidenav', function(event) {
+			var closeButton = $(containerSelector).find('.sidenav-close').first();
+			var closeButtonSelector = '#' + guid(closeButton, 'generatedLexiconSidenavCloseId');
+			var dataCloseButtonSelector ='lexicon.' + closeButtonSelector;
+
+			if (!doc.data(dataCloseButtonSelector)) {
+				doc.data(dataCloseButtonSelector, 'true');
+
+				doc.on('click.close.lexicon.sidenav', closeButtonSelector, function(event) {
 					event.preventDefault();
+
+					if (!instance.useDataAttribute) {
+						instance.element = doc.find(options.selector);
+					}
 
 					instance.toggle();
 				});
-
-				closeButton.data('click.lexicon.sidenav', true);
 			}
+
+			instance.closeButtonSelector = closeButtonSelector;
+			instance.dataCloseButtonSelector = dataCloseButtonSelector;
 		},
 
 		_onClickTrigger: function() {

--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -129,6 +129,39 @@
 			els.css(attribute, '');
 		},
 
+		destroy: function() {
+			var instance = this;
+			var element = instance.element;
+			var options = instance.options;
+
+			// Detach sidenav close
+
+			var closeButton = element.find('.sidenav-close').first();
+
+			if (instance.useDataAttribute) {
+				var simpleSidenav = instance._getSimpleSidenavNavigation();
+
+				closeButton = simpleSidenav.find('.sidenav-close').first();
+			}
+
+			closeButton.off('click.lexicon.sidenav');
+			closeButton.data('click.lexicon.sidenav', null);
+
+			// Detach toggler
+
+			if (options.useDelegate) {
+				doc.off('click.lexicon.sidenav', instance.togglerSelector);
+				doc.data(instance.dataTogglerSelector, null);
+			}
+			else {
+				element.off('click.lexicon.sidenav');
+			}
+
+			// Remove Side Navigation
+
+			element.data('lexicon.sidenav', null);
+		},
+
 		getSidenavLeftWidth: function(type, offset, width) {
 			var instance = this;
 
@@ -694,6 +727,9 @@
 					}
 				);
 			}
+
+			instance.togglerSelector = togglerSelector;
+			instance.dataTogglerSelector = dataTogglerSelector;
 		},
 
 		_onScreenChange: function() {

--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -684,6 +684,10 @@
 					'click.lexicon.sidenav',
 					togglerSelector,
 					function(event) {
+						if (!instance.useDataAttribute) {
+							instance.element = doc.find(options.selector);
+						}
+
 						instance.toggle();
 
 						event.preventDefault();

--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -900,4 +900,11 @@
 	Plugin.Constructor = SideNavigation;
 
 	$.fn.sideNavigation = Plugin;
+
+	$(function() {
+		var sidenav = $('[data-toggle="sidenav"]');
+		var target = sidenav.attr('data-target') || sidenav.attr('href');
+
+		Plugin.call(sidenav);
+	});
 }(jQuery);

--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -90,8 +90,12 @@
 				options.type = element.data('type');
 				options.typeMobile = element.data('type-mobile');
 				options.url = element.data('url');
-				options.useDelegate = element.data('use-delegate') || false;
+				options.useDelegate = element.data('use-delegate');
 				options.width = '';
+
+				if (options.useDelegate === undefined) {
+					options.useDelegate = true;
+				}
 			}
 			else { // find toggler
 				toggler = element.find(options.toggler);


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/sidenav/

You can destroy the plugin using $('#Id').sideNavigation('destroy'). I also made the toggle and close buttons work when using delegate with regular sidenav. If everything is correct, we won't need to destroy sideNavigation plugin in portal and should work as is.