### PR TITLE
Fix: <a class="badge badge-default"> text color should be blue on hover

### DIFF
--- a/src/scss/atlas-theme/_badges.scss
+++ b/src/scss/atlas-theme/_badges.scss
@@ -35,12 +35,13 @@
 .badge-default {
 	background-color: $badge-default-bg;
 	color: $badge-default-color;
+}
 
-	a {
-		&,
-		&:focus,
-		&:hover {
-			color: $badge-default-link-color;
-		}
+a.badge-default,
+.badge-default a {
+	&,
+	&:focus,
+	&:hover {
+		color: $badge-default-link-color;
 	}
 }


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/badges-and-labels/#badges

`<a class="badge badge-default" href="#1">Badge Default</a>` text color should be blue on hover.