### PR TITLE
Fix: Data url shouldn't place content inside multiple sidebar-body wh…

### DIFF
--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -615,7 +615,7 @@
 
 			eventTarget = eventTarget || sidenav;
 
-			var sidebarBody = sidenav.find('.sidebar-body');
+			var sidebarBody = sidenav.find('.sidebar-body').first();
 
 			if (!urlLoaded && sidebarBody.length && (typeof url === 'string' || $.isPlainObject(url))) {
 				sidenav.addClass('sidebar-loading');


### PR DESCRIPTION
…en nested

This fixes a bug in the document library admin section when the product menu is closed and the browser is refreshed. Data url will load content into the left nav and the nav on the right.