### PR TITLE
New tooltip bg color

### DIFF
--- a/src/scss/atlas-theme/variables/_tooltip.scss
+++ b/src/scss/atlas-theme/variables/_tooltip.scss
@@ -17,5 +17,5 @@ $tooltip-box-shadow-spread: $box-shadow-default-spread !default; // Atlas
 $tooltip-box-shadow-bg: $box-shadow-default-bg !default; // Atlas
 $tooltip-box-shadow: $tooltip-box-shadow-x $tooltip-box-shadow-y $tooltip-box-shadow-blur $tooltip-box-shadow-spread $tooltip-box-shadow-bg !default; // Atlas
 
-$tooltip-bg: #29353D !default;
+$tooltip-bg: #0E191D !default;
 $tooltip-opacity: 1 !default;


### PR DESCRIPTION
New bg color to avoid contrast issues:

![image](https://cloud.githubusercontent.com/assets/7963804/12922025/267372ec-cf50-11e5-952a-109d571c96e7.png)
