### PR TITLE
Fix: Side Navigation lazy loading doesn't try to reload content that …

### DIFF
--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -648,11 +648,13 @@
 
 			var urlLoaded = sidenav.data('url-loaded');
 
+			var readyState = urlLoaded ? urlLoaded.readyState : 0;
+
 			eventTarget = eventTarget || sidenav;
 
 			var sidebarBody = sidenav.find('.sidebar-body').first();
 
-			if (!urlLoaded && sidebarBody.length && (typeof url === 'string' || $.isPlainObject(url))) {
+			if (!readyState && sidebarBody.length && (typeof url === 'string' || $.isPlainObject(url))) {
 				sidenav.addClass('sidebar-loading');
 
 				urlLoaded = $.ajax(url).done(


### PR DESCRIPTION
…was never loaded

http://liferay.github.io/lexicon/content/sidenav/#lazy-loading-side-navigation-content

Turn off network 
Click Simple Sidenav 2 Toggler
Close Sidenav
Turn on network
Click Simple Sidenav 2 Toggler
Content should load