### PR TITLE
Fix: #132 add work around for ios not respecting overflow hidden on body

### DIFF
--- a/src/js/modals-ext.js
+++ b/src/js/modals-ext.js
@@ -1,0 +1,106 @@
+(function($) {
+	// https://bugs.webkit.org/show_bug.cgi?id=153852
+
+	var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+	$.extend($.fn.modal.Constructor.prototype, {
+		hideModal: function () {
+			var that = this;
+			this.$element.hide();
+			this.backdrop(function () {
+				that.$body.removeClass('modal-open');
+
+				// https://bugs.webkit.org/show_bug.cgi?id=153852
+
+				if (iOS && !(that.winScrollPos === 0)) {
+					window.scrollTo(0, that.winScrollPos);
+
+					that.$body.css({
+						position: '',
+						top: ''
+					});
+				}
+
+				that.resetAdjustments();
+				that.resetScrollbar();
+				that.$element.trigger('hidden.bs.modal');
+			});
+		},
+
+		show: function (_relatedTarget) {
+			var that = this;
+			var e = $.Event('show.bs.modal', { relatedTarget: _relatedTarget });
+
+			this.$element.trigger(e);
+
+			if (this.isShown || e.isDefaultPrevented()) {
+				return;
+			}
+
+			this.isShown = true;
+
+			this.checkScrollbar();
+			this.setScrollbar();
+
+			this.$body.addClass('modal-open');
+
+			// https://bugs.webkit.org/show_bug.cgi?id=153852
+
+			if (iOS) {
+				this.winScrollPos = window.scrollY;
+
+				if (!(this.winScrollPos === 0)) {
+					this.$body.css({
+						position: 'fixed',
+						top: -this.winScrollPos
+					});
+				}
+			}
+
+			this.escape();
+			this.resize();
+
+			this.$element.on('click.dismiss.bs.modal', '[data-dismiss="modal"]', $.proxy(this.hide, this));
+
+			this.$dialog.on('mousedown.dismiss.bs.modal', function () {
+				that.$element.one('mouseup.dismiss.bs.modal', function (e) {
+					if ($(e.target).is(that.$element)) {
+						that.ignoreBackdropClick = true;
+					}
+				});
+			});
+
+			this.backdrop(function () {
+				var transition = $.support.transition && that.$element.hasClass('fade');
+
+				if (!that.$element.parent().length) {
+					that.$element.appendTo(that.$body); // don't move modals dom position
+				}
+
+				that.$element
+					.show()
+					.scrollTop(0);
+
+				that.adjustDialog();
+
+				if (transition) {
+					that.$element[0].offsetWidth; // force reflow
+				}
+
+				that.$element.addClass('in');
+
+				that.enforceFocus();
+
+				var e = $.Event('shown.bs.modal', { relatedTarget: _relatedTarget });
+
+				transition ?
+					that.$dialog // wait for modal to slide in
+						.one('bsTransitionEnd', function () {
+							that.$element.trigger('focus').trigger(e)
+						})
+						.emulateTransitionEnd($.fn.modal.Constructor.TRANSITION_DURATION) :
+					that.$element.trigger('focus').trigger(e);
+			});
+		}
+	});
+})(jQuery);

--- a/src/scss/lexicon-base/_modals.scss
+++ b/src/scss/lexicon-base/_modals.scss
@@ -48,7 +48,7 @@
 }
 
 .modal-dialog {
-	@media screen and (max-width: $grid-float-breakpoint) {
+	@media screen and (max-width: $grid-float-breakpoint-max) {
 		bottom: 0;
 		left: 0;
 		margin: 0;
@@ -66,7 +66,7 @@
 	clear: both;
 	text-align: left;
 
-	@media screen and (max-width: $grid-float-breakpoint) {
+	@media screen and (max-width: $grid-float-breakpoint-max) {
 		bottom: 0;
 		position: absolute;
 		left: 0;
@@ -78,14 +78,6 @@
 	background-color: $modal-header-bg;
 	border-color: $modal-header-border-color;
 	color: $modal-header-color;
-}
-
-.modal-open {
-	bottom: 0;
-	left: 0;
-	position: fixed;
-	right: 0;
-	top: 0;
 }
 
 .modal-title {

--- a/templates/includes/header.ejs
+++ b/templates/includes/header.ejs
@@ -10,6 +10,7 @@
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<script src="<%= rootPath %>/js/bootstrap.js"></script>
 	<script src="<%= rootPath %>/js/collapsible-search.js"></script>
+	<script src="<%= rootPath %>/js/modals-ext.js"></script>
 	<script src="<%= rootPath %>/js/side-navigation.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Hey @natecavanaugh, I couldn't find a css only work around to this. I had to add an exception for ios in Bootstraps modal plugin.