### PR TITLE
Update: Search bar covers active style when navbars are in narrow column

### DIFF
--- a/src/scss/atlas-theme/_navbar.scss
+++ b/src/scss/atlas-theme/_navbar.scss
@@ -412,6 +412,7 @@
 				display: inline-block;
 				padding-bottom: $navbar-default-desktop-padding-vertical - $navbar-link-active-bottom-border-width;
 				padding-top: $navbar-default-desktop-padding-vertical;
+				z-index: 3;
 			}
 
 			&:after {


### PR DESCRIPTION
<img width="413" alt="narrow-navbar" src="https://cloud.githubusercontent.com/assets/788266/13718883/514dc8da-e7a3-11e5-9e0a-f9a347468919.png">
