### PR TITLE
Fix: IE text in card not truncating

### DIFF
--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -131,8 +131,7 @@
 		display: table-cell;
 		position: relative;
 		vertical-align: middle;
-
-		@include word-wrap;
+		word-break: break-all; // IE
 
 		.img-responsive {
 			max-width: none;


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/cards/#truncating-text-inside-horizontal-card-without-card-row-layout-fixed

<img width="727" alt="card-clamp-container" src="https://cloud.githubusercontent.com/assets/788266/14116785/63ef5fac-f596-11e5-80aa-85add0825b32.png">