### PR TITLE
Update: Focus outline for truncated links are cut off

### DIFF
--- a/src/scss/lexicon-base/_clamp.scss
+++ b/src/scss/lexicon-base/_clamp.scss
@@ -1,6 +1,7 @@
 .clamp-container {
 	left: $table-cell-padding;
-	margin: 0;
+	margin: -2px;
+	padding: 2px;
 	position: absolute;
 	right: $table-cell-padding;
 }


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/cards/#truncating-text-inside-horizontal-card-without-card-row-layout-fixed
http://liferay.github.io/lexicon/content/tables/

Change any of the text inside .clamp-container into links and focus, outline shouldn't be cut off.