### PR TITLE
Remove card header footer section

### DIFF
--- a/src/content/cards.html
+++ b/src/content/cards.html
@@ -5,18 +5,24 @@ section: Components
 
 <div class="row row-spacing uxgl-vertical-card">
 	<div class="col-md-12">
-		<h3>Default Card</h3>
+		<h3>Card</h3>
 
 		<blockquote class="blockquote-sm blockquote-success">
-			<p>Display card content vertically.</p>
+			<p>A container styled like a card for your stuff. Combine different Lexicon components inside a card to create a variety of cards.</p>
 		</blockquote>
 	</div>
 
 	<div class="col-md-4">
 		<div class="card">
-			<div class="card-header"><h4>Header</h4></div>
-			<div class="card-section"><h4>Section</h4></div>
-			<div class="card-footer"><h4>Footer</h4></div>
+			<div class="crop-img crop-img-bottom crop-img-center" style="height: 150px;">
+				<img alt="thumbnail" src="../../images/thumbnail_hot_air_ballon.jpg">
+			</div>
+			<div class="user-icon user-icon-danger user-icon-xxl" style="margin: -64px auto 0;position: relative;line-height:120px;border: 4px solid #FFF;"><span>JB</span></div>
+			<div class="card-block" style="text-align: center;">
+				<h3 style="margin:0;">Joe Bloggs</h4>
+				<h5 class="text-default" style="margin-top:0;">Administrator</h5>
+				<p>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</p>
+			</div>
 		</div>
 	</div>
 
@@ -26,11 +32,7 @@ section: Components
 	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse0"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse0">
-	<pre><code>```<div class="card">
-    <div class="card-header"><h1>Header</h1></div>
-    <div class="card-section"><h1>Section</h1></div>
-    <div class="card-footer"><h1>Footer</h1></div>
-</div>```</code></pre>
+	<pre><code class="html">```<div class="card">...</div>```</code></pre>
 </div>
 
 	</div>
@@ -38,90 +40,21 @@ section: Components
 
 <div class="row row-spacing uxgl-horizontal-card">
 	<div class="col-md-12">
-		<h3>Horizontal Card</h3>
+		<h3>Horizontal Card with Simple Grid</h3>
 
 		<blockquote class="blockquote-sm blockquote-success">
-			<p>Display card content horizontally. <code>.card-horizontal</code> uses a simplified version of Bootstrap 3's grid system to help align content. It is based on the 12 column grid (default), but columns can be customized to any size.</p>
-
-			<p>Card columns do not break at smaller screen widths. They were designed to help align small chunks of content and are not meant to be used for page layouts.</p>
-		</blockquote>
-	</div>
-
-	<div class="col-md-4">
-		<div class="card-horizontal">
-			<div class="card-row">
-				<div class="card-col-6">card-col-6</div>
-				<div class="card-col-6">card-col-6</div>
-			</div>
-		</div>
-	</div>
-
-	<div class="col-md-4">
-		<div class="card-horizontal">
-			<div class="card-row">
-				<div class="card-col-7">card-col-7</div>
-				<div class="card-col-4">card-col-4</div>
-			</div>
-		</div>
-	</div>
-
-	<div class="col-md-4">
-		<div class="card-horizontal">
-			<div class="card-row">
-				<div class="card-col-4">card-col-4</div>
-				<div class="card-col-7">card-col-7</div>
-			</div>
-		</div>
-	</div>
-
-	<div class="col-md-12">
-
-<div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse1"><span class="icon-caret-down"></span></a>
-</div>
-<div class="collapse" id="codeCollapse1">
-	<pre><code class="html">```<div class="card-horizontal">
-    <div class="card-row">
-        <div class="card-col-6">card-col-6</div>
-        <div class="card-col-6">card-col-6</div>
-    </div>
-</div>```</code></pre>
-</div>
-
-	</div>
-</div>
-
-<div class="row row-spacing uxgl-horizontal-card">
-	<div class="col-md-12">
-		<blockquote class="blockquote-sm blockquote-success">
-			<p>Create a column only as wide as its content with <code>card-col-field</code> and fill the remaing space with <code>card-col-content</code>. <code>card-col-field</code> has width: 1% and will expand only as wide as its content as long as <code>card-col-content</code> is present as a sibling.</p>
+			<p>Use <code>card-row</code> with <code>card-col-content</code> and <code>card-col-field</code> to create a number of custom horizontal cards. <code>card-col-field</code> used in conjunction with <code>card-col-content</code> will only expand as wide as its content. <code>card-col-content</code> will cover the remaining space.</p>
 		</blockquote>
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
+		<div class="card card-horizontal">
 			<div class="card-row card-row-padded">
 				<div class="card-col-field">
 					<span class="icon-folder-close-alt icon-monospaced" style="width: 90px;"></span>
 				</div>
 				<div class="card-col-content card-col-gutters">
 					<span>Fills Remaining Space</span>
-				</div>
-			</div>
-		</div>
-	</div>
-
-	<div class="col-md-6">
-		<div class="card-horizontal">
-			<div class="card-row card-row-padded">
-				<div class="card-col-field">
-					<span class="icon-folder-close-alt icon-monospaced" style="width: 90px;"></span>
-				</div>
-				<div class="card-col-content card-col-gutters">
-					<span>Fills Remaining Space</span>
-				</div>
-				<div class="card-col-field">
-					<span class="icon-folder-close-alt icon-monospaced" style="width: 140px;"></span>
 				</div>
 			</div>
 		</div>
@@ -133,16 +66,13 @@ section: Components
 	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse001"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse001">
-	<pre><code class="html">```<div class="card-horizontal">
+	<pre><code class="html">```<div class="card card-horizontal">
     <div class="card-row card-row-padded">
         <div class="card-col-field">
             <span class="icon-folder-close-alt icon-monospaced" style="width: 90px;"></span>
         </div>
         <div class="card-col-content card-col-gutters">
             <span>Fills Remaining Space</span>
-        </div>
-        <div class="card-col-field">
-            <span class="icon-folder-close-alt icon-monospaced" style="width: 140px;"></span>
         </div>
     </div>
 </div>```</code></pre>
@@ -152,29 +82,129 @@ section: Components
 	</div>
 </div>
 
-<div class="row row-spacing uxgl-horizontal-card">
+<div class="row row-spacing">
+	<div class="col-md-12">
+		<h3>Card Row Layout Fixed</h3>
+
+		<blockquote class="blockquote-sm blockquote-success">
+			<p>Sometimes you may have really long text that needs to fit inside <code>card-col-content</code>, just add class <code>card-row-layout-fixed</code> to the <code>card-row</code> and set a fixed width for each <code>card-col-field</code>.</p>
+		</blockquote>
+
+		<div class="alert alert-warning">
+			<span class="text-danger">card-row-layout-fixed</span> must be used to apply the css property <span class="text-danger">word-wrap: break-word</span> to <span class="text-danger">card-col-content</span> and <span class="text-danger">card-col-field</span>.
+		</div>
+	</div>
+
+	<div class="col-md-8 uxgl-horizontal-card">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed card-row-padded">
+				<div class="card-col-field" style="width: 90px;">
+					<span class="icon-folder-close-alt icon-monospaced"></span>
+				</div>
+				<div class="card-col-content card-col-gutters">
+					<span>ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span>
+				</div>
+				<div class="card-col-field" style="width: 60px;">
+					<span class="icon-folder-close-alt icon-monospaced"></span>
+				</div>
+			</div>
+		</div>
+	</div>
+
 	<div class="col-md-12">
 		<blockquote class="blockquote-sm blockquote-success">
-			<p>Vertically align content by setting the css property <code>vertical-align</code> on the card-col and align content horizontally by using <code>text-align</code>.</p>
+			<p>Use <code>card-row-layout-fixed</code> to create horizontal cards with an image on the left and text on the right and vice versa, just set a fixed width on the column containing the image.</p>
 		</blockquote>
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
-			<div class="card-row">
-				<div class="card-col-4" style="vertical-align: top;">top</div>
-				<div class="card-col-4">middle</div>
-				<div class="card-col-4" style="vertical-align: bottom;">bottom</div>
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed">
+				<div class="card-col-field" style="width: 150px;">
+					<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
+				</div>
+
+				<div class="card-col-field card-col-gutters">
+					<h4>So ristretto cappuccino</h4>
+
+					<p>Wings eu, pumpkin spice robusta.</p>
+				</div>
 			</div>
 		</div>
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed card-row-padded">
+				<div class="card-col-field" style="width: 121px;">
+					<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
+				</div>
+
+				<div class="card-col-field card-col-gutters">
+					<h4>So ristretto cappuccino</h4>
+
+					<p>Wings eu, pumpkin spice robusta.</p>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-md-6">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed">
+				<div class="card-col-field card-col-gutters">
+					<h4>So ristretto cappuccino</h4>
+
+					<p>Wings eu, pumpkin spice robusta.</p>
+				</div>
+				<div class="card-col-field" style="width: 150px;">
+					<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-md-6">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed card-row-padded">
+				<div class="card-col-field card-col-gutters">
+					<h4>So ristretto cappuccino</h4>
+
+					<p>Wings eu, pumpkin spice robusta.</p>
+				</div>
+				<div class="card-col-field" style="width: 121px;">
+					<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="row row-spacing uxgl-horizontal-card">
+	<div class="col-md-12">
+		<h3>Card Row Vertical Alignment Helpers</h3>
+
+		<blockquote class="blockquote-sm blockquote-success">
+			<p>Vertically align content by setting the css property <code>vertical-align</code> on the card-col and align content horizontally by using <code>text-align</code> or use the helper classes <code>card-row-valign-bottom</code>and <code>card-row-valign-top</code> on the <code>card-row</code> to vertically align all columns inside the row.</p>
+		</blockquote>
+	</div>
+
+	<div class="col-md-6">
+		<div class="card card-horizontal">
 			<div class="card-row">
-				<div class="card-col-4" style="text-align:left;">left</div>
-				<div class="card-col-4">center</div>
-				<div class="card-col-4" style="text-align:right;">right</div>
+				<div class="card-col-field" style="vertical-align: top;">top</div>
+				<div class="card-col-field">middle</div>
+				<div class="card-col-field" style="vertical-align: bottom;">bottom</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-md-6">
+		<div class="card card-horizontal">
+			<div class="card-row">
+				<div class="card-col-field" style="text-align:left;">left</div>
+				<div class="card-col-field">center</div>
+				<div class="card-col-field" style="text-align:right;">right</div>
 			</div>
 		</div>
 	</div>
@@ -185,11 +215,11 @@ section: Components
 	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse2"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse2">
-		<pre><code class="html">```<div class="card-horizontal">
+		<pre><code class="html">```<div class="card card-horizontal">
     <div class="card-row">
-        <div class="card-col-4" style="vertical-align: top;">top</div>
-        <div class="card-col-4">middle</div>
-        <div class="card-col-4" style="vertical-align: bottom;">bottom</div>
+        <div class="card-col-field" style="vertical-align: top;">top</div>
+        <div class="card-col-field">middle</div>
+        <div class="card-col-field" style="vertical-align: bottom;">bottom</div>
     </div>
 </div>```</code></pre>
 </div>
@@ -200,18 +230,18 @@ section: Components
 <div class="row row-spacing">
 	<div class="col-md-12">
 		<blockquote class="blockquote-sm blockquote-success">
-			<p>Add gutters to a specific card card column by using <code>.card-col-gutters</code>.</p>
+			<p>Add gutters to a specific card card column by using the class <code>card-col-gutters</code>.</p>
 		</blockquote>
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
-			<div class="card-row">
-				<div class="card-col-5">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed">
+				<div class="card-col-field" style="width: 150px;">
 					<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
 				</div>
 
-				<div class="card-col-7 card-col-gutters">
+				<div class="card-col-field card-col-gutters">
 					<h4>So ristretto cappuccino</h4>
 
 					<p>Wings eu, pumpkin spice robusta.</p>
@@ -226,13 +256,13 @@ section: Components
 	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse3"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse3">
-		<pre><code class="html">```<div class="card-horizontal">
-    <div class="card-row">
-        <div class="card-col-5">
+		<pre><code class="html">```<div class="card card-horizontal">
+    <div class="card-row" style="width: 150px;">
+        <div class="card-col-field">
             <img alt="thumbnail" class="img-responsive" src="/images/thumbnail_coffee.jpg">
         </div>
 
-        <div class="card-col-7 card-col-gutters">
+        <div class="card-col-field card-col-gutters">
             ...
         </div>
     </div>
@@ -243,18 +273,18 @@ section: Components
 
 	<div class="col-md-12">
 		<blockquote class="blockquote-sm blockquote-success">
-			<p>Use <code>.card-row-padded</code> with <code>.card-row</code> to add some spacing around a horizontal card.</p>
+			<p>Use <code>card-row-padded</code> on <code>card-row</code> to add some spacing around a horizontal card.</p>
 		</blockquote>
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
-			<div class="card-row card-row-padded">
-				<div class="card-col-5">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed card-row-padded">
+				<div class="card-col-field" style="width: 121px;">
 					<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
 				</div>
 
-				<div class="card-col-7 card-col-gutters">
+				<div class="card-col-field card-col-gutters">
 					<h4>So ristretto cappuccino</h4>
 					<p>Wings eu, pumpkin spice robusta.</p>
 				</div>
@@ -268,7 +298,7 @@ section: Components
 	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse4"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse4">
-	<pre><code class="html">```<div class="card-horizontal">
+	<pre><code class="html">```<div class="card card-horizontal">
     <div class="card-row card-row-padded">
         ...
     </div>
@@ -280,7 +310,7 @@ section: Components
 
 <div class="row row-spacing" id="truncatingText">
 	<div class="col-md-12">
-		<h3>Truncating Text Inside Horizontal Card</h3>
+		<h3>Truncating Text Inside Horizontal Card with Card Row Layout Fixed</h3>
 
 		<blockquote class="blockquote-sm blockquote-success">
 			<p>Use class <code>card-row-layout-fixed</code> on card row and add class <code>truncate-text</code> on a text element. Every column except the one that should expand to fill the remaining space needs to have a fixed width set.</p>
@@ -288,13 +318,13 @@ section: Components
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
+		<div class="card card-horizontal">
 			<div class="card-row card-row-layout-fixed card-row-padded">
-				<div class="card-col-5">
+				<div class="card-col-field" style="width: 150px;">
 					<img alt="thumbnail" class="img-responsive" src="../../images/thumbnail_placeholder.gif">
 				</div>
 
-				<div class="card-col-7 card-col-gutters">
+				<div class="card-col-field card-col-gutters">
 					<h4>So ristretto cappuccino</h4>
 					<p class="truncate-text">Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</p>
 				</div>
@@ -304,7 +334,7 @@ section: Components
 
 	<ul class="list-unstyled" style="clear:both;">
 		<li class="col-md-6">
-			<div class="card-horizontal">
+			<div class="card card-horizontal">
 				<div class="card-row card-row-layout-fixed card-row-padded">
 					<div class="card-col-field" style="width:60px;">
 						<span class="icon-folder-close-alt icon-monospaced" style="background-color: #EEE; height: 60px; line-height: 60px; width: 60px;"></span>
@@ -334,7 +364,7 @@ section: Components
 		</li>
 
 		<li class="col-md-6">
-			<div class="card-horizontal">
+			<div class="card card-horizontal">
 				<div class="card-row card-row-layout-fixed card-row-padded">
 					<div class="card-col-field" style="width:60px;">
 						<span class="icon-folder-close-alt icon-monospaced" style="background-color: #EEE; height: 60px; line-height: 60px; width: 60px;"></span>
@@ -364,7 +394,7 @@ section: Components
 		</li>
 
 		<li class="col-md-6">
-			<div class="card-horizontal">
+			<div class="card card-horizontal">
 				<div class="card-row card-row-layout-fixed card-row-padded">
 					<div class="card-col-field" style="width:60px;">
 						<span class="icon-folder-close-alt icon-monospaced" style="background-color: #EEE; height: 60px; line-height: 60px; width: 60px;"></span>
@@ -394,7 +424,7 @@ section: Components
 		</li>
 
 		<li class="col-md-6">
-			<div class="card-horizontal">
+			<div class="card card-horizontal">
 				<div class="card-row card-row-layout-fixed card-row-padded">
 					<div class="card-col-field" style="width:60px;">
 						<span class="icon-folder-close-alt icon-monospaced" style="background-color: #EEE; height: 60px; line-height: 60px; width: 60px;"></span>
@@ -436,8 +466,8 @@ section: Components
 		</blockquote>
 	</div>
 
-	<div class="col-xs-6">
-		<div class="card-horizontal">
+	<div class="col-md-6">
+		<div class="card card-horizontal">
 			<div class="card-row card-row-padded">
 				<div class="card-col-field">
 					<img alt="thumbnail" src="../../images/thumbnail_placeholder.gif" style="width:140px;">
@@ -453,8 +483,8 @@ section: Components
 		</div>
 	</div>
 
-	<div class="col-xs-6">
-		<div class="card-horizontal">
+	<div class="col-md-6">
+		<div class="card card-horizontal">
 			<div class="card-row card-row-padded">
 				<div class="card-col-field">
 					<img alt="thumbnail" src="../../images/thumbnail_placeholder.gif" style="width:140px;">
@@ -470,8 +500,8 @@ section: Components
 		</div>
 	</div>
 
-	<div class="col-xs-6">
-		<div class="card-horizontal">
+	<div class="col-md-6">
+		<div class="card card-horizontal">
 			<div class="card-row card-row-padded">
 				<div class="card-col-field">
 					<img alt="thumbnail" src="../../images/thumbnail_placeholder.gif" style="width:140px;">
@@ -487,7 +517,7 @@ section: Components
 		</div>
 	</div>
 
-	<div class="col-xs-6" style="clear:left;">
+	<div class="col-md-6" style="clear:left;">
 		<div class="checkbox checkbox-card checkbox-middle-left">
 			<label>
 				<input type="checkbox" value="">
@@ -522,7 +552,7 @@ section: Components
 		</div>
 	</div>
 
-	<div class="col-xs-6">
+	<div class="col-md-6">
 		<div class="card card-horizontal">
 			<div class="card-row card-row-padded">
 				<div class="card-col-field">
@@ -556,36 +586,39 @@ section: Components
 	</div>
 </div>
 
-<div class="row row-spacing uxgl-vertical-card">
+<div class="row row-spacing">
 	<div class="col-md-12">
 		<h3>Card Helper Classes</h3>
 
 		<blockquote class="blockquote-sm blockquote-success">
-			<p>Use <code>.card-rounded</code>, <code>.card-circle</code>, or <code>.card-square</code> on the card to quickly shape the borders.</p>
+			<p>Use classes <code>card-rounded</code>, <code>card-circle</code>, or <code>card-square</code> on the card to quickly shape the borders.</p>
 		</blockquote>
 	</div>
 
-	<div class="col-md-4">
-		<div class="card card-rounded">
-			<div class="card-header"><h4>Header</h4></div>
-			<div class="card-section"><h4>Section</h4></div>
-			<div class="card-footer"><h4>Footer</h4></div>
+	<div class="col-md-4 uxgl-horizontal-card">
+		<div class="card card-horizontal card-rounded">
+			<div class="card-row">
+				<div class="card-col-field">card-col-field</div>
+				<div class="card-col-field">card-col-field</div>
+			</div>
 		</div>
 	</div>
 
-	<div class="col-md-4">
-		<div class="card card-circle">
-			<div class="card-header"><h4>Header</h4></div>
-			<div class="card-section"><h4>Section</h4></div>
-			<div class="card-footer"><h4>Footer</h4></div>
+	<div class="col-md-4 uxgl-horizontal-card">
+		<div class="card card-horizontal card-circle">
+			<div class="card-row">
+				<div class="card-col-field">card-col-field</div>
+				<div class="card-col-field">card-col-field</div>
+			</div>
 		</div>
 	</div>
 
-	<div class="col-md-4">
-		<div class="card card-square">
-			<div class="card-header"><h4>Header</h4></div>
-			<div class="card-section"><h4>Section</h4></div>
-			<div class="card-footer"><h4>Footer</h4></div>
+	<div class="col-md-4 uxgl-horizontal-card">
+		<div class="card card-horizontal card-square">
+			<div class="card-row">
+				<div class="card-col-field">card-col-field</div>
+				<div class="card-col-field">card-col-field</div>
+			</div>
 		</div>
 	</div>
 
@@ -595,69 +628,77 @@ section: Components
 	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse5"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse5">
-	<pre><code class="html">```<div class="card card-rounded">...</div>
-<div class="card card-circle">...</div>
-<div class="card card-square">...</div>```</code></pre>
+	<pre><code class="html">```<div class="card card-horizontal card-rounded">...</div>
+<div class="card card-horizontal card-circle">...</div>
+<div class="card card-horizontal card-square">...</div>```</code></pre>
 </div>
 
 	</div>
 
 	<div class="col-md-12">
 		<blockquote class="blockquote-sm blockquote-success">
-			<p>Use <code>.divider</code> on an <code>```<hr>```</code> or <code>```<div>```</code> element to create a division between content inside a card.</p>
+			We didn't add <code>overflow: hidden</code> to the <code>card</code> class because it prevents nested dropdowns, popups, and tooltips from fully displaying. You can work around this by adding <code>border-radius</code> to the image or <code>overflow: hidden</code> to the card.
+		</blockquote>
+
+		<div class="alert alert-warning">
+			When using card border helper classes with images as the first or last item, add the css property <span class="text-danger">overflow: hidden</span> to the card or <span class="text-danger">border-radius</span> to the image.
+		</div>
+	</div>
+
+	<div class="col-xs-6 col-md-4">
+		<div class="card card-rounded" style="overflow: hidden;">
+			<div class="aspect-ratio aspect-ratio-16-to-9">
+				<img alt="thumbnail" src="../../images/thumbnail_hot_air_ballon.jpg">
+			</div>
+
+			<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+				<div class="card-col-content" style="text-align: center;height: 125px;">
+					<h3 style="margin:0;">Joe Bloggs</h3>
+					<h5 class="text-default" style="margin-top:0;">Administrator</h5>
+					<p>Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</p>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col-xs-12 col-sm-12 col-md-6">
+		<div class="card card-horizontal card-rounded">
+			<div class="card-row card-row-layout-fixed card-row-valign-top">
+				<div class="card-col-field" style="width:150px;">
+					<img class="img-responsive" src="../../images/thumbnail_dock.jpg" style="border-radius: 4px 0 0 4px;" />
+				</div>
+				<div class="card-col-content card-col-gutters">
+					<h4>Space Program</h4>
+					<div class="divider"></div>
+					<p>Because you live life on the edge of space.</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="row row-spacing">
+	<div class="col-md-12">
+		<h3>Card Dividers</h3>
+
+		<blockquote class="blockquote-sm blockquote-success">
+			<p>Use <code>```<hr class="divider" />```</code> or <code>```<div class="divider"></div>```</code> to create a horizontal division between content inside a card.</p>
 		</blockquote>
 	</div>
 
-	<div class="col-md-6">
-		<div class="card">
-			<div class="card-header"><h4>Header</h4></div>
-
-			<div class="card-section">
-				<h4>Section</h4>
-				<hr class="divider" />
-				<p>Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</p>
-			</div>
-
-			<div class="card-footer"><h4>Footer</h4></div>
-		</div>
-	</div>
-
 	<div class="col-md-6 uxgl-horizontal-card">
-		<div class="card-horizontal">
+		<div class="card card-horizontal">
 			<div class="card-row">
-				<div class="card-col-6 card-col-gutters">
-					<h4>Section</h4>
-					<hr class="divider" />
-					<p>Wings eu, pumpkin spice robusta, kopi-luwak mocha caffeine froth grounds.</p>
+				<div class="card-col-field">
+					card-col-field
 				</div>
-				<div class="card-col-6">card-col-6</div>
+				<div class="card-col-field card-col-gutters">
+					<h4>Title</h4>
+					<div class="divider"></div>
+					<p>card-col-field</p>
+				</div>
 			</div>
 		</div>
-	</div>
-
-	<div class="col-md-12">
-
-<div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse6"><span class="icon-caret-down"></span></a>
-</div>
-<div class="collapse" id="codeCollapse6">
-	<pre><code class="html">```<div class="card">
-    <div class="card-section">
-      <hr class="divider" />
-    </div>
-</div>
-
-<div class="card-horizontal">
-    <div class="card-row">
-        <div class="card-col-6 card-col-gutters">
-          <hr class="divider" />
-        </div>
-
-        <div class="card-col-6">card-col-6</div>
-    </div>
-</div>```</code></pre>
-</div>
-
 	</div>
 </div>
 

--- a/src/content/documents_and_media.html
+++ b/src/content/documents_and_media.html
@@ -482,16 +482,14 @@ section: Example Pages
 													<span class="sticker sticker-bottom sticker-warning">PNG</span>
 												</div>
 
-												<div class="card-row card-row-padded card-row-valign-top">
-													<div class="card-col-content clamp-horizontal" style="height: 75px;">
-														<div class="clamp-container">
-															<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-															<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
-															<span class="truncate-text">Approved</span>
-														</div>
+												<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+													<div class="card-col-content">
+														<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+														<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
+														<span class="truncate-text">Approved</span>
 													</div>
-													<div class="card-col-field">
-														<div class="dropdown">
+													<div class="card-col-field" style="width: 32px;">
+														<div class="dropdown" style="margin-left: 8px;">
 															<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 																<svg class="icon-monospaced lexicon-icon">
 																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
@@ -523,16 +521,14 @@ section: Example Pages
 													<span class="sticker sticker-bottom sticker-warning">PNG</span>
 												</div>
 
-												<div class="card-row card-row-padded card-row-valign-top">
-													<div class="card-col-content clamp-horizontal" style="height: 75px;">
-														<div class="clamp-container">
-															<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-															<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
-															<span class="truncate-text">Approved</span>
-														</div>
+												<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+													<div class="card-col-content">
+														<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+														<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
+														<span class="truncate-text">Approved</span>
 													</div>
-													<div class="card-col-field">
-														<div class="dropdown">
+													<div class="card-col-field" style="width: 32px;">
+														<div class="dropdown" style="margin-left: 8px;">
 															<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 																<svg class="icon-monospaced lexicon-icon">
 																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
@@ -564,16 +560,14 @@ section: Example Pages
 													<span class="sticker sticker-bottom sticker-warning">PNG</span>
 												</div>
 
-												<div class="card-row card-row-padded card-row-valign-top">
-													<div class="card-col-content clamp-horizontal" style="height: 75px;">
-														<div class="clamp-container">
-															<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-															<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
-															<span class="truncate-text">Approved</span>
-														</div>
+												<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+													<div class="card-col-content">
+														<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+														<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
+														<span class="truncate-text">Approved</span>
 													</div>
-													<div class="card-col-field">
-														<div class="dropdown">
+													<div class="card-col-field" style="width: 32px;">
+														<div class="dropdown" style="margin-left: 8px;">
 															<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 																<svg class="icon-monospaced lexicon-icon">
 																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
@@ -605,16 +599,14 @@ section: Example Pages
 													<span class="sticker sticker-bottom sticker-warning">PNG</span>
 												</div>
 
-												<div class="card-row card-row-padded card-row-valign-top">
-													<div class="card-col-content clamp-horizontal" style="height: 75px;">
-														<div class="clamp-container">
-															<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-															<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
-															<span class="truncate-text">Approved</span>
-														</div>
+												<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+													<div class="card-col-content">
+														<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+														<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
+														<span class="truncate-text">Approved</span>
 													</div>
-													<div class="card-col-field">
-														<div class="dropdown">
+													<div class="card-col-field" style="width: 32px;">
+														<div class="dropdown" style="margin-left: 8px;">
 															<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 																<svg class="icon-monospaced lexicon-icon">
 																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
@@ -646,16 +638,14 @@ section: Example Pages
 													<span class="sticker sticker-bottom sticker-warning">PNG</span>
 												</div>
 
-												<div class="card-row card-row-padded card-row-valign-top">
-													<div class="card-col-content clamp-horizontal" style="height: 75px;">
-														<div class="clamp-container">
-															<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-															<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
-															<span class="truncate-text">Approved</span>
-														</div>
+												<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+													<div class="card-col-content">
+														<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+														<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
+														<span class="truncate-text">Approved</span>
 													</div>
-													<div class="card-col-field">
-														<div class="dropdown">
+													<div class="card-col-field" style="width: 32px;">
+														<div class="dropdown" style="margin-left: 8px;">
 															<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 																<svg class="icon-monospaced lexicon-icon">
 																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
@@ -687,16 +677,14 @@ section: Example Pages
 													<span class="sticker sticker-bottom sticker-warning">PNG</span>
 												</div>
 
-												<div class="card-row card-row-padded card-row-valign-top">
-													<div class="card-col-content clamp-horizontal" style="height: 75px;">
-														<div class="clamp-container">
-															<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-															<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
-															<span class="truncate-text">Approved</span>
-														</div>
+												<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+													<div class="card-col-content">
+														<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+														<span class="truncate-text" title="thumbnail_dock.jpg">thumbnail_dock.jpg</span>
+														<span class="truncate-text">Approved</span>
 													</div>
-													<div class="card-col-field">
-														<div class="dropdown">
+													<div class="card-col-field" style="width: 32px;">
+														<div class="dropdown" style="margin-left: 8px;">
 															<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 																<svg class="icon-monospaced lexicon-icon">
 																	<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />

--- a/src/content/extending_cards.html
+++ b/src/content/extending_cards.html
@@ -17,22 +17,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/thumbnail_coffee.jpg);">
 						<span class="sticker sticker-bottom sticker-info">JPG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="thumbnail_coffee.jpg">thumbnail_coffee.jpg</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="thumbnail_coffee.jpg">thumbnail_coffee.jpg</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -55,22 +53,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/switch_on_icon.png);">
 						<span class="sticker sticker-bottom sticker-warning">PNG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="switch_on_icon.png">switch_on_icon.png</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="switch_on_icon.png">switch_on_icon.png</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -93,22 +89,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/tv-at-beach.png);">
 						<span class="sticker sticker-bottom sticker-warning">PNG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="tv-at-beach.png">tv-at-beach.png</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="tv-at-beach.png">tv-at-beach.png</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -131,22 +125,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image:url(../../images/liferay_logo_tagline.png);">
 						<span class="sticker sticker-bottom sticker-warning">PNG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="liferay_logo_tagline.png">liferay_logo_tagline.png</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="liferay_logo_tagline.png">liferay_logo_tagline.png</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -178,22 +170,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-center" style="background-image:url(../../images/thumbnail_coffee.jpg);">
 						<span class="sticker sticker-bottom sticker-info">JPG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="thumbnail_coffee.jpg">thumbnail_coffee.jpg</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="thumbnail_coffee.jpg">thumbnail_coffee.jpg</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -216,22 +206,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-center" style="background-image:url(../../images/switch_on_icon.png);">
 						<span class="sticker sticker-bottom sticker-warning">PNG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="switch_on_icon.png">switch_on_icon.png</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="switch_on_icon.png">switch_on_icon.png</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -254,22 +242,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-center" style="background-image:url(../../images/tv-at-beach.png);">
 						<span class="sticker sticker-bottom sticker-warning">PNG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="tv-at-beach.png">tv-at-beach.png</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="tv-at-beach.png">tv-at-beach.png</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -292,22 +278,20 @@ section: Extending Components
 					<div class="aspect-ratio aspect-ratio-bg-center" style="background-image:url(../../images/liferay_logo_tagline.png);">
 						<span class="sticker sticker-bottom sticker-warning">PNG</span>
 					</div>
-					<div class="card-row card-row-padded card-row-valign-top">
-						<div class="card-col-content clamp-horizontal" style="height: 75px;">
-							<div class="clamp-container">
-								<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
-								<span class="truncate-text" title="liferay_logo_tagline.png">liferay_logo_tagline.png</span>
-								<span class="truncate-text">Approved</span>
-							</div>
+					<div class="card-row card-row-layout-fixed card-row-padded card-row-valign-top">
+						<div class="card-col-content">
+							<span class="truncate-text">Aldcott Gage George Polwarth-Kitchener</span>
+							<span class="truncate-text" title="liferay_logo_tagline.png">liferay_logo_tagline.png</span>
+							<span class="truncate-text">Approved</span>
 						</div>
-						<div class="card-col-field">
-							<div class="dropdown">
+						<div class="card-col-field" style="width: 32px;">
+							<div class="dropdown" style="margin-left: 8px;">
 								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
 									<svg class="icon-monospaced lexicon-icon">
 										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
 									</svg>
 								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
+								<ul class="dropdown-menu dropdown-menu-left-side">
 									<li><a href="#1">Download</a></li>
 									<li><a href="#1">Edit</a></li>
 									<li><a href="#1">Move</a></li>
@@ -320,212 +304,69 @@ section: Extending Components
 					</div>
 				</div>
 			</label>
-		</div>
-	</div>
-</div>
-
-<div class="row row-spacing">
-	<div class="col-md-12">
-		<h3>Checkbox Inside Horizontal Card</h3>
-	</div>
-
-	<div class="col-xs-6">
-		<div class="checkbox checkbox-card checkbox-middle-left">
-			<label>
-				<input type="checkbox" value="">
-				<div class="card card-horizontal">
-					<div class="card-row card-row-padded">
-						<div class="card-col-field">
-							<svg class="icon-monospaced lexicon-icon">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#folder" />
-							</svg>
-						</div>
-						<div class="card-col-content card-col-gutters clamp-horizontal">
-							<div class="clamp-container"><span class="truncate-text" title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span></div>
-						</div>
-						<div class="card-col-field" style="vertical-align:top;">
-							<div class="dropdown">
-								<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
-									<svg class="icon-monospaced lexicon-icon">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
-									</svg>
-								</a>
-								<ul class="dropdown-menu dropdown-menu-right">
-									<li><a href="#1">Download</a></li>
-									<li><a href="#1">Edit</a></li>
-									<li><a href="#1">Move</a></li>
-									<li><a href="#1">Checkout</a></li>
-									<li><a href="#1">Permissions</a></li>
-									<li><a href="#1">Move to Recycle Bin</a></li>
-								</ul>
-							</div>
-						</div>
-					</div>
-				</div>
-			</label>
-		</div>
-	</div>
-
-	<div class="col-xs-6">
-		<div class="card card-horizontal">
-			<div class="card-row card-row-padded">
-				<div class="card-col-field">
-					<img src="{{rootPath}}/images/switch_on_icon.png" />
-				</div>
-				<div class="card-col-field">
-					<img src="{{rootPath}}/images/switch_off_icon.png" />
-				</div>
-				<div class="card-col-content card-col-gutters clamp-horizontal">
-					<div class="clamp-container"><span class="truncate-text" title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual">ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual</span></div>
-				</div>
-				<div class="card-col-field" style="vertical-align:top;">
-					<div class="dropdown">
-						<a class="dropdown-toggle" data-toggle="dropdown" href="#1">
-							<svg class="icon-monospaced lexicon-icon">
-								<use xlink:href="{{rootPath}}/images/icons/icons.svg#ellipsis-v" />
-							</svg>
-						</a>
-						<ul class="dropdown-menu dropdown-menu-right">
-							<li><a href="#1">Download</a></li>
-							<li><a href="#1">Edit</a></li>
-							<li><a href="#1">Move</a></li>
-							<li><a href="#1">Checkout</a></li>
-							<li><a href="#1">Permissions</a></li>
-							<li><a href="#1">Move to Recycle Bin</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
 		</div>
 	</div>
 </div>
 
 <div class="extend-cards-page row row-spacing">
 	<div class="col-md-12">
-		<h3>Vertical Card Example</h3>
-
-		<blockquote class="blockquote-sm blockquote-success">
-			<p>Cards are a great way of summarizing a lot of related content, such as products, bookmarks, and favorites. Use the cards component as a foundation to quickly mimic common patterns used throughout the web.</p>
-
-			<p>The card header and footer classes, were created to make it easier to style headers and footers across several cards, only one <code>.card-header</code> and one <code>.card-footer</code> should appear per card.</p>
-
-			<p>Use <code>.card-section</code> to group blocks of content and place between header and footer.</p>
-		</blockquote>
+		<h3>Vertical Card Examples</h3>
 	</div>
 
 	<div class="col-lg-4 col-md-5">
 		<div class="card">
-			<div class="card-header">
-				<div class="nameplate" style="margin: 15px 0 10px;">
-					<div class="nameplate-icon">
-						<div class="user-icon">
-							<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
-						</div>
+			<div class="nameplate" style="padding: 8px;">
+				<div class="nameplate-field" style="vertical-align: middle;">
+					<div class="user-icon">
+						<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_placeholder.gif">
 					</div>
+				</div>
 
-					<div class="nameplate-content">
-						<h4>Space Program <small>Category</small></h4>
-					</div>
+				<div class="nameplate-content">
+					<h3 style="margin: 0;">Space Program <small>Category</small></h3>
 				</div>
 			</div>
 
-			<div class="card-section">
-				<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_dock.jpg">
-			</div>
+			<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_dock.jpg">
 
-			<div class="divider"></div>
-
-			<div class="card-footer">
-				<a class="btn btn-block btn-default" href="#" role="button" style="margin-bottom:10px;">Subscribe</a>
+			<div class="card-block">
+				<a class="btn btn-block btn-default" href="#" role="button">Subscribe</a>
 			</div>
 		</div>
 	</div>
 
-	<div class="col-md-12">
-
-<div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse0"><span class="icon-caret-down"></span></a>
-</div>
-<div class="collapse" id="codeCollapse0">
-	<pre><code class="html">```<div class="card">
-    <div class="card-header">
-        <div class="nameplate">...</div>
-    </div>
-
-    <div class="card-section">...</div>
-
-    <hr class="divider" />
-
-    <div class="card-footer">...</div>
-</div>```</code></pre>
-</div>
-
-	</div>
-</div>
-
-<div class="extend-cards-page row row-spacing">
-	<div class="col-md-12">
-		<h3>Make Content Span Full Width</h3>
-
-		<blockquote class="blockquote-sm blockquote-success">
-			<p>Don't wrap content in <code>.card-header</code>, <code>.card-footer</code>, or <code>.card-section</code> to make images and content span the full width of the card.</p>
-		</blockquote>
-	</div>
-	<div class="col-md-4">
+	<div class="col-lg-4 col-md-5">
 		<div class="card">
 			<div class="figure">
 				<img alt="thumbnail" class="img-responsive" src="{{rootPath}}/images/thumbnail_dock.jpg">
 				<div class="figcaption-bottom figcaption-lg monospace">10 Most Delicious Space Foods</div>
 			</div>
 
-			<div class="card-section">
+			<div class="card-block">
 				<p class="text-default">Number 1</p>
 				<h4>Mystery Meal</h4>
 				<p>Because you like to live life on the edge of space.</p>
 			</div>
 		</div>
 	</div>
-
-	<div class="col-md-12">
-
-<div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse1"><span class="icon-caret-down"></span></a>
-</div>
-<div class="collapse" id="codeCollapse1">
-	<pre><code class="html">```<div class="card">
-    <div class="figure">
-        <img class="img-responsive" src="thumbnail.jpg">
-        <div class="figcaption-bottom figcaption-lg monospace">10 Most Delicious Space Foods</div>
-    </div>
-    <div class="card-section">
-        <p class="text-default">Number 1</p>
-        <h4>Mystery Meal</h4>
-        <p>Because you like to live life on the edge of space.</p>
-    </div>
-</div>```</code></pre>
-</div>
-
-	</div>
 </div>
 
 <div class="row row-spacing">
 	<div class="col-md-12">
-		<h3>Make an Image Fill Card-col</h3>
-
-		<blockquote class="blockquote-sm blockquote-success">Use the <a href="../images-and-thumbnails/#cropImage">crop-img</a> and <a href="../figures">figures</a> component to make an image fill a card column.</blockquote>
+		<h3>Horizontal Card Examples</h3>
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
-			<div class="card-row">
-				<div class="card-col-5">
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed">
+				<div class="card-col-field" style="width: 150px;">
 					<div class="crop-img crop-img-center crop-img-middle">
-						<img alt="thumbnail" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg">
+						<img alt="thumbnail" src="{{rootPath}}/images/thumbnail_hot_air_ballon.jpg" style="width: 230px;">
 					</div>
 				</div>
 
-				<div class="card-col-7 card-col-gutters">
-					<h4>Travel to Space by Balloon</h4>
+				<div class="card-col-content card-col-gutters">
+					<h4>Space Balloon</h4>
 
 					<p>Space Program LLC is offering balloon rides to space!</p>
 
@@ -541,21 +382,15 @@ section: Extending Components
 	</div>
 
 	<div class="col-md-6">
-		<div class="card-horizontal">
-			<div class="card-row">
-				<div class="card-col-5">
-					<div class="figure">
-						<div class="crop-img crop-img-center crop-img-middle">
-							<img alt="Image a dock. of" src="../../images/thumbnail_dock.jpg">
-						</div>
-
-						<div class="figcaption-bottom">
-							Carajillo strong, grounds redeye.
-						</div>
+		<div class="card card-horizontal">
+			<div class="card-row card-row-layout-fixed">
+				<div class="card-col-field" style="width: 150px;">
+					<div class="crop-img crop-img-center crop-img-middle">
+						<img alt="Image a dock. of" src="../../images/thumbnail_dock.jpg" style="width: 230px;">
 					</div>
 				</div>
 
-				<div class="card-col-7 card-col-gutters">
+				<div class="card-col-content card-col-gutters">
 					<h4>Space Elevator</h4>
 
 					<p>Space Program LLC is building an elevator to space!</p>
@@ -570,31 +405,6 @@ section: Extending Components
 			</div>
 		</div>
 	</div>
-
-	<div class="col-md-12">
-
-<div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse4"><span class="icon-caret-down"></span></a>
-</div>
-<div class="collapse" id="codeCollapse4">
-	<pre><code class="html">```<div class="card-horizontal">
-    <div class="card-row">
-        <div class="card-col-5">
-            <img class="img-responsive" src="thumbnail.jpg">
-        </div>
-        <div class="card-col-7 card-col-gutters">
-            <h4>Travel to Space by Balloon</h4>
-            <p>Space Program LLC is offering balloon rides to space!</p>
-        </div>
-        <div style="margin: 10px 0;">
-            <button class="btn btn-primary btn-xs" type="button">Sign Up</button>
-            <button class="btn btn-link btn-xs" type="button">No Thanks</button>
-        </div>
-    </div>
-</div>```</code></pre>
-</div>
-
-	</div>
 </div>
 
 <div class="extend-cards-page row row-spacing">
@@ -602,9 +412,9 @@ section: Extending Components
 		<h3>Some Alternate Styles</h3>
 	</div>
 
-	<div class="col-md-4">
+	<div class="col-md-5">
 		<div class="card">
-			<div class="card-section text-center">
+			<div class="card-block text-center">
 				<p style="font-size: 21px; font-weight: 200; margin-bottom: 0; margin-top: 20px;">New Users</p>
 				<p>14,543</p>
 			</div>
@@ -615,64 +425,71 @@ section: Extending Components
 		<div class="card">
 			<div class="card-label">Browser Stats</div>
 
-			<div class="card-section">
-				<table class="table-striped">
-					<tr>
-						<td>Chrome</td>
-						<td>25%</td>
-					</tr>
-					<tr>
-						<td>Mozilla Firefox</td>
-						<td>5%</td>
-					</tr>
-					<tr>
-						<td>Safari</td>
-						<td>15%</td>
-					</tr>
-					<tr>
-						<td>Internet Explorer</td>
-						<td>54%</td>
-					</tr>
-					<tr>
-						<td>Other</td>
-						<td>1%</td>
-					</tr>
-				</table>
-			</div>
+			<table class="table table-striped">
+				<tr>
+					<td class="table-cell-content">Chrome</td>
+					<td class="table-cell-field">54%</td>
+				</tr>
+				<tr>
+					<td class="table-cell-content">Internet Explorer</td>
+					<td class="table-cell-field">15%</td>
+				</tr>
+				<tr>
+					<td class="table-cell-content">Mozilla Firefox</td>
+					<td class="table-cell-field">14%</td>
+				</tr>
+				<tr>
+					<td class="table-cell-content">Safari</td>
+					<td class="table-cell-field">9%</td>
+				</tr>
+				<tr>
+					<td class="table-cell-content">Opera</td>
+					<td class="table-cell-field">2%</td>
+				</tr>
+				<tr>
+					<td class="table-cell-content">Other</td>
+					<td class="table-cell-field">6%</td>
+				</tr>
+			</table>
 		</div>
 	</div>
 
-	<div class="col-md-8 control-panel">
+	<div class="col-md-7 control-panel">
 		<div class="card" style="max-width:none;">
-			<div class="card-row">
-				<div class="card-col-11 card-column">Browser</div>
-				<div class="card-col-1 card-column" style="word-break: normal;">Stats</div>
-			</div>
-
-			<div class="card-section">
-				<table class="table-striped">
+			<table class="table table-striped">
+				<thead style="background-color: #f8f8f8;">
 					<tr>
-						<td>Chrome</td>
-						<td>25%</td>
+						<th class="table-cell-content">Browser</th>
+						<th class="table-cell-field">Stats</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td class="table-cell-content">Chrome</td>
+						<td class="table-cell-field">54%</td>
 					</tr>
 					<tr>
-						<td>Mozilla Firefox</td>
-						<td>5%</td>
+						<td class="table-cell-content">Internet Explorer</td>
+						<td class="table-cell-field">15%</td>
 					</tr>
 					<tr>
-						<td>Safari</td>
-						<td>15%</td>
+						<td class="table-cell-content">Mozilla Firefox</td>
+						<td class="table-cell-field">14%</td>
 					</tr>
 					<tr>
-						<td>Internet Explorer</td>
-						<td>54%</td>
+						<td class="table-cell-content">Safari</td>
+						<td class="table-cell-field">9%</td>
 					</tr>
 					<tr>
-						<td>Other</td>
-						<td>1%</td>
+						<td class="table-cell-content">Opera</td>
+						<td class="table-cell-field">2%</td>
 					</tr>
-				</table>
-			</div>
+					<tr>
+						<td class="table-cell-content">Other</td>
+						<td class="table-cell-field">6%</td>
+					</tr>
+				</tbody>
+			</table>
 		</div>
 
 		<div class="card" style="max-width:none;">

--- a/src/scss/atlas-theme/_cards.scss
+++ b/src/scss/atlas-theme/_cards.scss
@@ -1,5 +1,4 @@
-.card,
-.card-horizontal {
+.card {
 	box-shadow: $card-box-shadow;
 
 	a {

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -28,41 +28,21 @@
 
 .card-horizontal {
 	position: relative;
+}
 
-	&.card-circle {
-		[class*="card-col"] {
-			&:first-child {
-				border-radius: $card-circle-border-radius 0 0 $card-circle-border-radius;
-			}
+// Card Simple Grid
 
-			&:last-child {
-				border-radius: 0 $card-circle-border-radius $card-circle-border-radius 0;
-			}
-		}
-	}
+.card-col-content,
+.card-col-field {
+	display: table-cell;
+	position: relative;
+	vertical-align: middle;
 
-	&.card-rounded {
-		[class*="card-col"] {
-			&:first-child {
-				border-radius: $card-rounded-border-radius 0 0 $card-rounded-border-radius;
-			}
-
-			&:last-child {
-				border-radius: 0 $card-rounded-border-radius $card-rounded-border-radius 0;
-			}
-		}
-	}
-
-	&.card-square {
-		[class*="card-col"] {
-			&:first-child {
-				border-radius: 0;
-			}
-
-			&:last-child {
-				border-radius: 0;
-			}
-		}
+	figure,
+	.figure {
+		height: 100%;
+		margin-bottom: 0;
+		width: 100%;
 	}
 }
 
@@ -98,22 +78,15 @@
 			margin-right: -10px;
 		}
 	}
-
-	[class*="card-col"] {
-		display: table-cell;
-		position: relative;
-		vertical-align: middle;
-		word-break: break-all; // IE
-
-		.img-responsive {
-			max-width: none;
-			width: 101%;
-		}
-	}
 }
 
 .card-row-layout-fixed {
 	table-layout: fixed;
+
+	.card-col-content,
+	.card-col-field {
+		word-wrap: break-word;
+	}
 
 	.card-col-field {
 		width: auto;
@@ -156,25 +129,51 @@
 	}
 }
 
-[class*="card-col"] {
-	figure,
-	.figure {
-		height: 100%;
-		margin-bottom: 0;
-		width: 100%;
-	}
-}
+// Card Border Helpers
 
 .card-circle {
 	border-radius: $card-circle-border-radius;
+
+	.card-col-content,
+	.card-col-field {
+		&:first-child {
+			border-radius: $card-circle-border-radius 0 0 $card-circle-border-radius;
+		}
+
+		&:last-child {
+			border-radius: 0 $card-circle-border-radius $card-circle-border-radius 0;
+		}
+	}
 }
 
 .card-rounded {
 	border-radius: $card-rounded-border-radius;
+
+	.card-col-content,
+	.card-col-field {
+		&:first-child {
+			border-radius: $card-rounded-border-radius 0 0 $card-rounded-border-radius;
+		}
+
+		&:last-child {
+			border-radius: 0 $card-rounded-border-radius $card-rounded-border-radius 0;
+		}
+	}
 }
 
 .card-square {
 	border-radius: 0;
+
+	.card-col-content,
+	.card-col-field {
+		&:first-child {
+			border-radius: 0;
+		}
+
+		&:last-child {
+			border-radius: 0;
+		}
+	}
 }
 
 // Checkbox and Radio Cards

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -1,10 +1,13 @@
-.card,
-.card-horizontal {
+.card {
 	background-color: $card-bg;
 	border: $card-border-width solid $card-border;
 	border-radius: $card-border-radius;
 	margin-bottom: $card-margin-bottom;
 	position: relative;
+
+	.card-row {
+		width: 100%;
+	}
 
 	.divider {
 		background-color: $card-divider-bg;
@@ -13,39 +16,10 @@
 		margin-bottom: 10px;
 		margin-top: 10px;
 	}
-}
-
-.card {
-	.card-row {
-		width: 100%;
-	}
 
 	.figure {
 		overflow: visible;
 	}
-}
-
-.card-header,
-.card-footer,
-.card-section {
-	@include clearfix();
-
-	.divider {
-		margin-left: -$card-gutter-width;
-		margin-right: -$card-gutter-width;
-	}
-}
-
-.card-header {
-	padding: 1px $card-gutter-width 0;
-}
-
-.card-footer {
-	padding: 0 $card-gutter-width 1px;
-}
-
-.card-section {
-	padding: 1px $card-gutter-width;
 }
 
 .card-horizontal {
@@ -195,56 +169,14 @@
 
 .card-circle {
 	border-radius: $card-circle-border-radius;
-
-	.card-header,
-	.card-section,
-	.card-footer {
-		&:first-child {
-			border-top-left-radius: $card-circle-border-radius;
-			border-top-right-radius: $card-circle-border-radius;
-		}
-
-		&:last-child {
-			border-bottom-left-radius: $card-circle-border-radius;
-			border-bottom-right-radius: $card-circle-border-radius;
-		}
-	}
 }
 
 .card-rounded {
 	border-radius: $card-rounded-border-radius;
-
-	.card-header,
-	.card-section,
-	.card-footer {
-		&:first-child {
-			border-top-left-radius: $card-rounded-border-radius;
-			border-top-right-radius: $card-rounded-border-radius;
-		}
-
-		&:last-child {
-			border-bottom-left-radius: $card-rounded-border-radius;
-			border-bottom-right-radius: $card-rounded-border-radius;
-		}
-	}
 }
 
 .card-square {
 	border-radius: 0;
-
-	.card-header,
-	.card-section,
-	.card-footer {
-		&:first-child {
-			border-top-left-radius: 0;
-			border-top-right-radius: 0;
-		}
-
-		&:last-child {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-		}
-	}
 }
 
 // Checkbox and Radio Cards

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -195,14 +195,6 @@
 	margin-left: 0;
 	margin-top: 0;
 	z-index: 1;
-
-	&:checked,
-	&:focus {
-		~ .card {
-			border-color: rgba(red($card-border-focus), green($card-border-focus), blue($card-border-focus), 0.6);
-			box-shadow: 0 0 3px 2px rgba(red($card-border-focus), green($card-border-focus), blue($card-border-focus), 0.6);
-		}
-	}
 }
 
 .checkbox-bottom-left,

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -24,6 +24,7 @@
 
 .card-block {
 	padding: $card-gutter-width;
+	word-wrap: break-word;
 }
 
 .card-horizontal {

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -223,7 +223,7 @@
 			padding-left: $checkbox-left-card-padding;
 		}
 
-		.card-row {
+		> .card-row {
 			padding-left: $checkbox-left-card-padding;
 		}
 	}
@@ -240,7 +240,7 @@
 			padding-right: $checkbox-right-card-padding;
 		}
 
-		.card-row {
+		> .card-row {
 			padding-right: $checkbox-right-card-padding;
 		}
 	}

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -22,6 +22,10 @@
 	}
 }
 
+.card-block {
+	padding: $card-gutter-width;
+}
+
 .card-horizontal {
 	position: relative;
 

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -70,12 +70,6 @@
 	width: 1%;
 }
 
-@for $i from 1 through $grid-columns {
-	.card-col-#{$i} {
-		width: percentage(($i / $grid-columns));
-	}
-}
-
 .card-row {
 	display: table;
 	height: 100%;

--- a/src/scss/lexicon-base/variables/_cards.scss
+++ b/src/scss/lexicon-base/variables/_cards.scss
@@ -12,7 +12,6 @@ $checkbox-position: 15px !default;
 
 $card-bg: #FFF !default;
 $card-border: $gray-lighter !default;
-$card-border-focus: $input-border-focus !default;
 $card-border-radius: $border-radius-base !default;
 
 $card-circle-border-radius: 20px !default;


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/cards/
http://liferay.github.io/lexicon/content/extending-cards/

Breaking: Remove card-col-# (not used in portal)
Breaking: Remove card-header, card-footer (not a big issue in portal)
Breaking: Replace card-section with card-block (not used in portal)
Breaking: Remove card focus styles (should be added in portal, cards dont share the same focus styles)
Site: Update docs and examples
