### PR TITLE
Update: truncate-text and table-cell-content older browser css fallback

### DIFF
--- a/src/scss/lexicon-base/_tables.scss
+++ b/src/scss/lexicon-base/_tables.scss
@@ -58,7 +58,7 @@ th {
 	min-width: 100px;
 	position: relative;
 	width: auto;
-	word-break: break-all \ ; // IE 8, 9
+	word-break: break-all \9; // IE 8, 9
 	word-wrap: break-word;
 }
 

--- a/src/scss/lexicon-base/_type.scss
+++ b/src/scss/lexicon-base/_type.scss
@@ -73,7 +73,7 @@ mark,
 td,
 th {
 	.truncate-text {
-		white-space: normal \ ; // IE 8, 9
+		white-space: normal \9; // IE 8, 9
 	}
 }
 
@@ -82,7 +82,7 @@ th {
 
 	@include text-overflow;
 
-	word-break: normal \ ; // IE 8, 9
+	word-break: normal \9; // IE 8, 9
 	word-wrap: normal;
 }
 


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/typography/#truncate-text
http://liferay.github.io/lexicon/content/tables/