### PR TITLE
Fix: Side Navigation mobile bug introduced in 4a3ae4f

### DIFF
--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -708,6 +708,7 @@
 				var fixedMenu = type === 'fixed' || type === 'fixed-push';
 
 				var menu = container.find('.sidenav-menu').first();
+				var navigation = container.find(options.navigation).first();
 
 				var menuWidth;
 
@@ -734,6 +735,8 @@
 					}
 				}
 
+				var closed = container.hasClass('closed');
+
 				if (!desktop) {
 					menuWidth = originalMenuWidth;
 
@@ -742,13 +745,17 @@
 					}
 
 					if (sidenavRight) {
-						menu.css(positionDirection, menuWidth).css('width', menuWidth);
+						if (closed) {
+							menu.css(positionDirection, menuWidth);
+						}
+
+						menu.css('width', menuWidth);
 					}
 
 					screenStartDesktop = false;
 				}
 
-				if (!container.hasClass('closed')) {
+				if (!closed) {
 					instance.clearStyle('min-height');
 					instance.showSidenav();
 					instance.setEqualHeight();


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/documents-and-media/

Broke sidenav in mobile at https://github.com/liferay/lexicon/commit/4a3ae4faf5c1e8b8603a60c42b02e255dba0fc9d. You can see the bug (in develop) if you open the info panel in mobile and resize the browser.

