### PR TITLE
Breaking: Use open instead of closed to toggle sidenav

### DIFF
--- a/src/content/documents_and_media.html
+++ b/src/content/documents_and_media.html
@@ -11,15 +11,13 @@ section: Example Pages
 					<div class="sidebar-header">
 						<h4>
 							<a href="#1">
-								<span class="sidebar-header-logo">
-									<svg class="icon-monospaced lexicon-icon">
-										<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
-									</svg>
-								</span>
+								<svg class="icon-monospaced lexicon-icon sticker sticker-success sticker-static">
+									<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
+								</svg>
 								<span>Squareup</span>
 							</a>
 
-							<a class="sidenav-close" href="#1">
+							<a class="pull-right sidenav-close" href="#1">
 								<svg class="icon-monospaced lexicon-icon">
 									<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 								</svg>
@@ -188,7 +186,7 @@ section: Example Pages
 
 							<ul class="management-bar-nav management-bar-nav-right nav">
 								<li>
-									<a class="btn btn-default" href="#documentsAndMediaRightSidenav" id="documentsAndMediaRightSidenavToggler">
+									<a class="active btn btn-default open" href="#documentsAndMediaRightSidenav" id="documentsAndMediaRightSidenavToggler">
 										<span class="icon-info-sign icon-monospaced"></span>
 									</a>
 								</li>
@@ -216,7 +214,7 @@ section: Example Pages
 						</div>
 					</div>
 
-					<div class="container-fluid-1280 sidenav-container sidenav-js-fouc" id="documentsAndMediaRightSidenav">
+					<div class="container-fluid-1280 open sidenav-container sidenav-js-fouc" id="documentsAndMediaRightSidenav">
 						<div class="sidenav-menu-slider">
 							<div class="sidebar sidebar-default sidenav-menu">
 								<div class="sidebar-header">

--- a/src/content/sidenav.html
+++ b/src/content/sidenav.html
@@ -64,11 +64,11 @@ section: Components (JS)
 			Avoid the flash of unstyled content when using the Javascript api by adding the class <span class="text-danger">sidenav-js-fouc</span> to the <span class="text-danger">sidenav-container</span>.
 		</div>
 
-		<button class="btn btn-default sidenav-toggler" data-target="#mySidenavContainerId" style="margin-bottom:5px;">
+		<button class="active open btn btn-default sidenav-toggler" data-target="#mySidenavContainerId" style="margin-bottom:5px;">
 			Sidenav Toggler
 		</button>
 
-		<div class="sidenav-container sidenav-js-fouc" id="mySidenavContainerId">
+		<div class="open sidenav-container sidenav-js-fouc" id="mySidenavContainerId">
 			<div class="sidenav-menu-slider" style="background:#FFF;">
 				<div class="sidenav-menu">
 					<div class="col-md-12">
@@ -113,11 +113,11 @@ section: Components (JS)
 
 <div class="row row-spacing sidenav-demo-container">
 	<div class="col-md-12">
-		<button class="btn btn-default sidenav-toggler1" style="margin-bottom:5px;">
+		<button class="active open btn btn-default sidenav-toggler1" style="margin-bottom:5px;">
 			Sidenav Toggler 1
 		</button>
 
-		<div class="sidenav-container sidenav-js-fouc" id="mySidenavContainerId1">
+		<div class="open sidenav-container sidenav-js-fouc" id="mySidenavContainerId1">
 			<div class="sidenav-menu-slider" style="background:#FFF;">
 				<div class="sidenav-menu">
 					<div class="col-md-12">
@@ -181,18 +181,18 @@ section: Components (JS)
 			</a>
 		</div>
 
-		<div class="closed sidenav-fixed sidenav-menu-slider" id="simpleSidenav">
+		<div class="sidenav-fixed sidenav-menu-slider" id="simpleSidenav">
 			<div class="sidebar sidebar-default sidenav-menu">
 				<div class="sidebar-header">
 					<h4>
 						<a href="#1">
-							<svg class="icon-monospaced lexicon-icon sidebar-header-logo">
+							<svg class="icon-monospaced lexicon-icon sticker sticker-static sticker-default">
 								<use xlink:href="{{rootPath}}/images/icons/icons.svg#staging" />
 							</svg>
 							<span>Simple Sidenav</span>
 						</a>
 
-						<a class="sidenav-close" href="#1" id="sidenavClose1">
+						<a class="pull-right sidenav-close" href="#1" id="sidenavClose1">
 							<svg aria-hidden="true" class="icon-monospaced lexicon-icon">
 								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 							</svg>
@@ -231,9 +231,9 @@ section: Components (JS)
 		</blockquote>
 
 		<div class="side-navigation-data-api-buttons">
-			<a class="btn btn-default" data-content="#wrapper" data-open-class="simple-sidenav-2-open" data-toggle="sidenav" data-type="relative" data-use-delegate="true" href="#simpleSidenav2">Simple Sidenav 2 Toggler</a>
+			<a class="btn btn-default" data-content="body" data-toggle="sidenav" href="#simpleSidenav2">Simple Sidenav 2 Toggler</a>
 
-			<a class="btn btn-default" data-content="#wrapper" data-open-class="simple-sidenav-2-open" data-toggle="sidenav" data-type="fixed-push" data-use-delegate="true" href="#simpleSidenav2">
+			<a class="btn btn-default" data-content="body" data-toggle="sidenav" data-type="fixed-push" data-type-mobile="fixed-push" href="#simpleSidenav2">
 				Another Simple Sidenav 2 Toggler
 			</a>
 
@@ -246,18 +246,19 @@ section: Components (JS)
 			</a>
 		</div>
 
-		<div class="closed sidenav-fixed sidenav-menu-slider" id="simpleSidenav2">
+		<div class="sidenav-fixed sidenav-menu-slider" id="simpleSidenav2">
 			<div class="sidebar sidebar-default sidenav-menu">
 				<div class="sidebar-header">
 					<h4>
 						<a href="#1">
-							<svg class="icon-monospaced lexicon-icon sidebar-header-logo" style="background-color: red;">
+
+							<svg class="icon-monospaced lexicon-icon sticker sticker-static sticker-danger">
 								<use xlink:href="{{rootPath}}/images/icons/icons.svg#home" />
 							</svg>
 							<span>Simple Sidenav 2</span>
 						</a>
 
-						<a class="sidenav-close" href="#1">
+						<a class="pull-right sidenav-close" href="#1">
 							<svg aria-hidden="true" class="icon-monospaced lexicon-icon">
 								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
 							</svg>
@@ -296,9 +297,9 @@ section: Components (JS)
 </head>
 
 <div id="#wrapper">
-    <a class="btn btn-default" data-content="#wrapper" data-toggle="sidenav" data-type="fixed-push" href="#simpleSidenav">Simple Sidenav Toggler</a>
+    <a class="btn btn-default" data-content="body" data-toggle="sidenav" data-type="fixed-push" href="#simpleSidenav2">Simple Sidenav 2 Toggler</a>
 
-    <div class="closed sidenav-fixed sidenav-menu-slider" id="simpleSidenav">
+    <div class="closed sidenav-fixed sidenav-menu-slider" id="simpleSidenav2">
         <div class="sidebar sidebar-default sidenav-menu">
             ...
         </div>
@@ -322,7 +323,50 @@ section: Components (JS)
 		</blockquote>
 
 		<div>
-			<a class="btn btn-default" data-content="#wrapper" data-open-class="simple-sidenav-2-open" data-toggle="sidenav" data-type="relative" data-url="{{rootPath}}/partials/alerts" data-use-delegate="true" href="#simpleSidenav2">Simple Sidenav 2 Toggler</a>
+			<a class="btn btn-default" data-content="body" data-toggle="sidenav" data-type="fixed-push" data-url="{{rootPath}}/partials/alerts" href="#simpleSidenav3">Simple Sidenav 3 Toggler</a>
+		</div>
+
+		<div class="sidenav-fixed sidenav-menu-slider" id="simpleSidenav3">
+			<div class="sidebar sidebar-default sidenav-menu">
+				<div class="sidebar-header">
+					<h4>
+						<a href="#1">
+							<svg class="icon-monospaced lexicon-icon sticker sticker-static sticker-warning">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#home" />
+							</svg>
+							<span>Simple Sidenav 3</span>
+						</a>
+
+						<a class="pull-right sidenav-close" href="#1">
+							<svg aria-hidden="true" class="icon-monospaced lexicon-icon">
+								<use xlink:href="{{rootPath}}/images/icons/icons.svg#times" />
+							</svg>
+						</a>
+					</h4>
+				</div>
+
+				<div class="sidebar-body">
+
+				</div>
+
+				<div class="sidebar-footer">
+					<div class="nameplate">
+						<div class="nameplate-field">
+							<div class="user-icon user-icon-warning">
+								:D
+							</div>
+						</div>
+
+						<div class="nameplate-content">
+							<h4 class="user-heading">Joe Bloggs<small class="user-subheading">Subheading</small></h4>
+						</div>
+
+						<div class="nameplate-field">
+							<a class="icon-monospaced" href="#1"></a>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 
 		<h4>Using the Options API</h4>
@@ -474,12 +518,12 @@ $('#myTogglerId').sideNavigation('hide').sideNavigation('visible'); // returns f
 	$('#showSimpleSidenav2').on('click', function(event) {
 		event.preventDefault();
 
-		$('[href="#simpleSidenav2"]').sideNavigation('show');
+		$('[href="#simpleSidenav2"]').first().sideNavigation('show');
 	});
 
 	$('#hideSimpleSidenav2').on('click', function(event) {
 		event.preventDefault();
 
-		$('[href="#simpleSidenav2"]').sideNavigation('hide');
+		$('[href="#simpleSidenav2"]').first().sideNavigation('hide');
 	});
 </script>

--- a/src/js/side-navigation.js
+++ b/src/js/side-navigation.js
@@ -114,6 +114,7 @@
 			// instantiate using data attribute
 
 			if (useDataAttribute) {
+				options.closedClass = toggler.data('closed-class') || 'closed';
 				options.content = toggler.data('content');
 				options.equalHeight = false;
 				options.loadingIndicatorTPL = toggler.data('loading-indicator-tpl') || options.loadingIndicatorTPL;
@@ -230,6 +231,7 @@
 				var content = $(options.content).first();
 				var sidenav = $(options.container);
 
+				var closedClass = options.closedClass;
 				var openClass = options.openClass;
 
 				var toggler = instance.toggler;
@@ -249,11 +251,14 @@
 					});
 				});
 
-				content.addClass('sidenav-transition');
-				sidenav.addClass('sidenav-transition closed');
+				if (content.hasClass(openClass)) {
+					content.addClass('sidenav-transition').addClass(closedClass).removeClass(openClass);
+				}
+
+				sidenav.addClass('sidenav-transition');
 				toggler.addClass('sidenav-transition');
 
-				content.removeClass(openClass);
+				sidenav.addClass(closedClass).removeClass(openClass);
 				toggler.removeClass(openClass).removeClass('active');
 			}
 		},
@@ -354,6 +359,7 @@
 				var content = $(options.content).first();
 				var sidenav = $(options.container);
 
+				var closedClass = options.closedClass;
 				var openClass = options.openClass;
 
 				var toggler = options.toggler;
@@ -383,15 +389,14 @@
 				});
 
 				sidenav.addClass('sidenav-transition');
-				toggler.addClass('sidenav-transition').addClass('active');
+				toggler.addClass('sidenav-transition');
 
 				if (desktopFixedPush || mobileFixedPush) {
-					content.addClass('sidenav-transition');
-					content.addClass(openClass);
-					toggler.addClass(openClass);
+					content.addClass('sidenav-transition').addClass(openClass).removeClass(closedClass);
 				}
 
-				sidenav.removeClass('closed');
+				sidenav.addClass(openClass).removeClass(closedClass);
+				toggler.addClass('active').addClass(openClass);
 			}
 		},
 
@@ -475,8 +480,8 @@
 
 			instance[widthMethod](container);
 
-			container.addClass('sidenav-transition').toggleClass('closed', !closed);
-			toggler.addClass('sidenav-transition').toggleClass('active', closed);
+			container.addClass('sidenav-transition').toggleClass('closed', !closed).toggleClass('open', closed);
+			toggler.addClass('sidenav-transition').toggleClass('active', closed).toggleClass('open', closed);
 		},
 
 		toggleSimpleSidenav: function() {
@@ -586,10 +591,13 @@
 
 		_isSimpleSidenavClosed: function() {
 			var instance = this;
+			var options = instance.options;
 
-			var container = $(instance.options.container);
+			var openClass = options.openClass;
 
-			return container.hasClass('closed');
+			var container = $(options.container);
+
+			return !container.hasClass(openClass);
 		},
 
 		_loadUrl: function(sidenav, url, eventTarget) {
@@ -639,10 +647,6 @@
 
 				doc.on('click.close.lexicon.sidenav', closeButtonSelector, function(event) {
 					event.preventDefault();
-
-					if (!instance.useDataAttribute) {
-						instance.toggler = container;
-					}
 
 					instance.toggle();
 				});
@@ -697,6 +701,7 @@
 			var options = instance.options;
 
 			var container = $(options.container);
+			var toggler = instance.toggler;
 
 			var screenStartDesktop = instance._setScreenSize();
 
@@ -721,7 +726,8 @@
 					instance.hideSidenav();
 					instance.clearStyle('min-height');
 
-					container.addClass('closed');
+					container.addClass('closed').removeClass('open');
+					toggler.removeClass('active').removeClass('open');
 
 					screenStartDesktop = false;
 
@@ -814,13 +820,15 @@
 			var options = instance.options;
 
 			var container = $(options.container);
+			var toggler = instance.toggler;
 
 			var mobile = instance.mobile;
 			var type = mobile ? options.typeMobile : options.type;
 
 			if (!instance.useDataAttribute) {
 				if (mobile) {
-					container.addClass('closed');
+					container.addClass('closed').removeClass('open');
+					toggler.removeClass('active').removeClass('open');
 				}
 
 				if (options.position === 'right') {

--- a/src/scss/_site.scss
+++ b/src/scss/_site.scss
@@ -613,13 +613,6 @@ body.fixed {
 
 // Site Main Nav
 
-#wrapper.open,
-#wrapper.simple-sidenav-2-open {
-	@media screen and (min-width: $grid-float-breakpoint) {
-		padding-left: 320px;
-	}
-}
-
 .side-navigation-data-api-buttons {
 	margin-bottom: 15px;
 
@@ -829,6 +822,20 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 // Side Navigation Component Page
+
+body {
+	left: 0;
+	position: relative;
+}
+
+body.open {
+	left: 320px;
+	overflow: hidden;
+}
+
+body.sidenav-transition {
+	overflow: hidden;
+}
 
 #mySidebar {
 	background-color: #222328;

--- a/src/scss/lexicon-base/_side-navigation.scss
+++ b/src/scss/lexicon-base/_side-navigation.scss
@@ -3,28 +3,9 @@
 	padding-right: floor(($grid-gutter-width / 2));
 }
 
-.sidenav-fixed {
-	&.sidenav-right {
-		> .sidenav-menu-slider {
-			left: auto;
-			right: 0;
-		}
-	}
-
-	> .sidenav-menu-slider {
-		bottom: 0;
-		left: 0;
-		position: fixed;
-		top: 0;
-		z-index: $zindex-navbar-fixed + 5;
-	}
-}
-
 .sidenav-container {
 	position: relative;
-}
 
-.sidenav-container.closed {
 	> .sidenav-menu-slider {
 		visibility: hidden;
 		width: 0;
@@ -32,6 +13,12 @@
 
 	> .sidenav-content {
 		left: 0;
+	}
+}
+
+.sidenav-container.open {
+	> .sidenav-menu-slider {
+		visibility: visible;
 	}
 }
 
@@ -58,26 +45,20 @@
 	z-index: 10;
 }
 
-.sidenav-container.sidenav-right {
-	.sidenav-content {
-		left: auto;
-		right: 0;
-	}
+.sidenav-fixed > .sidenav-menu-slider {
+	bottom: 0;
+	left: 0;
+	position: fixed;
+	top: 0;
+	z-index: $zindex-sidenav;
+}
+
+.sidenav-right > .sidenav-menu-slider {
+	left: auto;
+	right: 0;
 
 	.sidenav-menu {
 		right: 0;
-	}
-
-	.sidenav-menu-slider {
-		right: 0;
-	}
-}
-
-.sidenav-fixed.sidenav-container {
-	overflow: hidden;
-
-	&.closed {
-		overflow: visible;
 	}
 }
 
@@ -86,11 +67,20 @@
 	visibility: hidden;
 }
 
-.sidenav-transition,
-.sidenav-transition .sidenav-content,
-.sidenav-transition .sidenav-menu-slider,
-.sidenav-transition .sidenav-menu-slider .sidenav-menu {
-	@include transition(all 0.5s ease);
+// JS API Transition
+
+.sidenav-transition {
+	.sidenav-content,
+	.sidenav-menu,
+	.sidenav-menu-slider {
+		@include transition($sidenav-transition);
+	}
+}
+
+// Simple Sidenav Transition
+
+.sidenav-transition {
+	@include transition($sidenav-transition);
 }
 
 // Simple Sidenav
@@ -100,21 +90,31 @@
 	left: 0;
 	position: fixed;
 	top: 0;
+	visibility: hidden;
+	width: 0;
 
-	&.closed {
-		visibility: hidden;
-		width: 0;
+	&.open {
+		visibility: visible;
+		width: $sidenav-width;
 	}
-}
 
-.sidenav-fixed.sidenav-menu-slider.sidenav-right {
-	left: auto;
-	right: 0;
+	.sidenav-menu {
+		position: absolute;
+	}
 }
 
 .sidenav-menu-slider {
 	&,
 	.sidenav-menu {
-		width: 320px;
+		width: $sidenav-width;
+	}
+
+	&.sidenav-right {
+		left: auto;
+		right: 0;
+
+		.sidenav-menu {
+			right: 0;
+		}
 	}
 }

--- a/src/scss/lexicon-base/_variables.scss
+++ b/src/scss/lexicon-base/_variables.scss
@@ -16,6 +16,7 @@
 @import "variables/panels";
 @import "variables/progress-bars";
 @import "variables/toolbars";
+@import "variables/side-navigation";
 @import "variables/sidebar";
 @import "variables/stickers";
 @import "variables/tables";

--- a/src/scss/lexicon-base/variables/_side-navigation.scss
+++ b/src/scss/lexicon-base/variables/_side-navigation.scss
@@ -1,0 +1,3 @@
+$sidenav-transition: all 0.5s ease !default;
+$sidenav-width: 320px !default;
+$zindex-sidenav: $zindex-navbar-fixed + 5 !default;


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/sidenav/
http://liferay.github.io/lexicon/content/documents-and-media/

Breaking: Sidenav should use open instead of closed to display nav for easier customization with common tutorials found on the web
Update: Move sidenav transition to variable
Update: Reduce css specificity of sidenav js api
Update: Active class should be removed from toggler when using sidenav-close button

Hey @natecavanaugh, this fixes #170 and should go in with https://issues.liferay.com/browse/LPS-65790. Everything should function the same except sidenavs toggle with open instead of closed. The closed class is still needed by the js api for now.