### PR TITLE
Fix: Table-heading-nowrap should work on .table-cell-content in thead

### DIFF
--- a/src/scss/lexicon-base/_tables.scss
+++ b/src/scss/lexicon-base/_tables.scss
@@ -158,6 +158,10 @@ th {
 	}
 }
 
+.table-responsive .table-heading-nowrap > thead > tr > .table-cell-content {
+	white-space: nowrap;
+}
+
 // Table Vertical Align
 
 .table-valign-bottom {


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/tables/