### PR TITLE
Fix: Panel-title should break-word not break-all

### DIFF
--- a/src/scss/lexicon-base/_panels.scss
+++ b/src/scss/lexicon-base/_panels.scss
@@ -1,8 +1,8 @@
 .panel-title {
 	font-size: $panel-title-font-size;
 	font-weight: $panel-title-font-weight;
-
-	@include word-wrap(break-word);
+	overflow-wrap: break-word;
+	word-wrap: break-word;
 }
 
 .panel-group {


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/panels/