### PR TITLE
Breaking: Remove bourbon dependency

### DIFF
--- a/src/scss/_site.scss
+++ b/src/scss/_site.scss
@@ -75,9 +75,8 @@ section.row {
 	position: absolute;
 	right: 15px;
 	top: 50%;
-
-	@include transform(translateY(-50%));
-
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 	z-index: 5;
 
 	.dropdown-menu {
@@ -94,9 +93,8 @@ section.row {
 	min-width: 170px;
 	position: absolute;
 	top: 50%;
-
-	@include transform(translateY(-50%));
-
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 	z-index: -1;
 
 	&:focus {
@@ -107,26 +105,25 @@ section.row {
 .animated-toggle.navbar-toggle .icon-bar {
 	position: relative;
 	top: 0;
-
-	@include transition-delay(0s 0s 0.2s 0s);
-	@include transition-duration(0.2s);
-	@include transition-property(background, opacity, top, transform);
-	@include transition-timing-function($ease-in-out-circ);
+	transition-delay: 0s 0s 0.2s 0s;
+	transition-duration: 0.2s;
+	transition-property: background, opacity, top, transform;
+	transition-timing-function: cubic-bezier(0.785,  0.135, 0.150, 0.860);
 }
 
 .main-nav-open {
 	.animated-toggle.navbar-toggle {
 		.icon-bar:nth-of-type(even) {
 			top: 6px;
-
-			@include transform(rotate(45deg));
-			@include transition-delay(0s 0s 0s 0.2s);
+			-ms-transform: rotate(45deg);
+			transform: rotate(45deg);
+			transition-delay: 0s 0s 0s 0.2s;
 		}
 
 		.icon-bar:nth-of-type(4) {
 			top: -6px;
-
-			@include transform(rotate(-45deg));
+			-ms-transform: rotate(-45deg);
+			transform: rotate(-45deg);
 		}
 
 		.icon-bar:nth-of-type(odd) {
@@ -539,21 +536,18 @@ body.fixed {
 		}
 	}
 
-	@include keyframes(exclamationHover) {
+	@keyframes exclamationHover {
 		0% {
-			@include transform(scale(1));
+			transform: scale(1);
 		}
 
 		60% {
-			@include transform(scale(1.5));
-
 			stroke-width: 10px;
+			transform: scale(1.5);
 		}
 
 		100% {
-			fill: #EC297B;
-
-			@include transform(scale(1));
+			transform: scale(1);
 		}
 	}
 
@@ -564,8 +558,9 @@ body.fixed {
 		stroke-width: 40px;
 
 		&:hover {
-			@include animation(exclamationHover 0.25s $ease-out-back);
-			@include animation-fill-mode(both);
+			animation: exclamationHover 0.25s cubic-bezier(0.175,  0.885, 0.320, 1.275);
+			animation-fill-mode: both;
+			fill: #EC297B;
 		}
 	}
 }
@@ -739,7 +734,7 @@ $mainNavWidth: 220px;
 
 	#mainNav,
 	#mainContent {
-		@include transition(all 0.25s ease);
+		transition: all 0.25s ease;
 	}
 }
 
@@ -893,8 +888,6 @@ body.sidenav-transition {
 	}
 
 	.sidenav-main-content h3 {
-		@include background-image(linear-gradient(top, #242B39 50%, #1E2639 100%));
-
 		border-bottom: 1px solid #1E2639;
 		color: #F8F8F8;
 		margin: 0 -20px;

--- a/src/scss/atlas-theme/_buttons.scss
+++ b/src/scss/atlas-theme/_buttons.scss
@@ -21,7 +21,7 @@
 	&.disabled,
 	&[disabled],
 	fieldset[disabled] & {
-		@include opacity($btn-disabled-opacity);
+		opacity: $btn-disabled-opacity;
 	}
 }
 

--- a/src/scss/atlas-theme/_cards.scss
+++ b/src/scss/atlas-theme/_cards.scss
@@ -12,8 +12,8 @@
 .radio-middle-left input[type="radio"],
 .radio-middle-left label > input[type="radio"] {
 	margin-top: 0;
-
-	@include transform(translateY(-50%));
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 }
 
 .checkbox-middle-right input[type="checkbox"],
@@ -21,6 +21,6 @@
 .radio-middle-right input[type="radio"],
 .radio-middle-right label > input[type="radio"] {
 	margin-top: 0;
-
-	@include transform(translateY(-50%));
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 }

--- a/src/scss/atlas-theme/_forms.scss
+++ b/src/scss/atlas-theme/_forms.scss
@@ -18,8 +18,8 @@ label, .control-label {
 }
 
 select.form-control {
-	@include prefixer(appearance, none, moz webkit);
-
+	-moz-appearance: none;
+	-webkit-appearance: none;
 	background-position: right center;
 	background-repeat: no-repeat;
 	background-size: 18px auto;

--- a/src/scss/atlas-theme/_list-group.scss
+++ b/src/scss/atlas-theme/_list-group.scss
@@ -6,7 +6,8 @@
 .list-group-item-content {
 	&.clamp-horizontal {
 		.clamp-container {
-			@include transform(none);
+			-ms-transform: none;
+			transform: none;
 		}
 	}
 

--- a/src/scss/atlas-theme/_modals.scss
+++ b/src/scss/atlas-theme/_modals.scss
@@ -1,5 +1,5 @@
 .modal-backdrop.in {
-	@include opacity($modal-backdrop-opacity);
+	opacity: $modal-backdrop-opacity;
 }
 
 .modal-content {
@@ -30,9 +30,7 @@
 		height: $modal-title-line-height;
 		line-height: $modal-title-line-height;
 		margin: 0;
-
-		@include opacity(1);
-
+		opacity: 1;
 		overflow: hidden;
 		text-shadow: none;
 		width: $modal-title-line-height;
@@ -41,8 +39,7 @@
 		&:focus,
 		&:hover {
 			color: $modal-header-close-color;
-
-			@include opacity(1);
+			opacity: 1;
 
 			@media screen and (min-width: $grid-float-breakpoint) {
 				color: $modal-desktop-header-close-color;

--- a/src/scss/atlas-theme/_pager.scss
+++ b/src/scss/atlas-theme/_pager.scss
@@ -27,8 +27,7 @@
 		> span {
 			background-color: $pager-disabled-bg;
 			border-color: $pager-disabled-border;
-
-			@include opacity(0.5);
+			opacity: 0.5;
 		}
 	}
 

--- a/src/scss/atlas-theme/_pagination.scss
+++ b/src/scss/atlas-theme/_pagination.scss
@@ -48,7 +48,7 @@
 			&,
 			&:focus,
 			&:hover {
-				@include opacity(0.5);
+				opacity: 0.5;
 			}
 		}
 	}

--- a/src/scss/lexicon-base/_aspect-ratio.scss
+++ b/src/scss/lexicon-base/_aspect-ratio.scss
@@ -21,15 +21,15 @@
 .aspect-ratio-center img {
 	left: 50%;
 	right: auto;
-
-	@include transform(translateX(-50%));
+	-ms-transform: translateX(-50%);
+	transform: translateX(-50%);
 }
 
 .aspect-ratio-middle img {
 	bottom: auto;
 	top: 50%;
-
-	@include transform(translateY(-50%));
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 }
 
 .aspect-ratio-right img {

--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -119,7 +119,8 @@
 	}
 
 	.clamp-horizontal .clamp-container {
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 
@@ -134,7 +135,8 @@
 	}
 
 	.clamp-horizontal .clamp-container {
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 

--- a/src/scss/lexicon-base/_clamp.scss
+++ b/src/scss/lexicon-base/_clamp.scss
@@ -9,8 +9,8 @@
 .clamp-horizontal {
 	.clamp-container {
 		overflow: hidden;
-
-		@include transform(translateY(-50%));
+		-ms-transform: translateY(-50%);
+		transform: translateY(-50%);
 	}
 }
 

--- a/src/scss/lexicon-base/_crop-image.scss
+++ b/src/scss/lexicon-base/_crop-image.scss
@@ -12,8 +12,8 @@
 
 .crop-img-center img {
 	left: 50%;
-
-	@include transform(translateX(-50%));
+	-ms-transform: translateX(-50%);
+	transform: translateX(-50%);
 }
 
 .crop-img-right img {
@@ -28,10 +28,11 @@
 
 .crop-img-middle img {
 	top: 50%;
-
-	@include transform(translateY(-50%));
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 }
 
 .crop-img-center.crop-img-middle img {
-	@include transform(translate(-50%, -50%));
+	-ms-transform: translate(-50%, -50%);
+	transform: translate(-50%, -50%);
 }

--- a/src/scss/lexicon-base/_dropdowns.scss
+++ b/src/scss/lexicon-base/_dropdowns.scss
@@ -126,8 +126,8 @@
 
 .dropdown-menu-center {
 	left: 50%;
-
-	@include transform(translateX(-50%));
+	-ms-transform: translateX(-50%);
+	transform: translateX(-50%);
 }
 
 .dropdown-menu-left-side {
@@ -149,9 +149,8 @@
 	left: auto;
 	margin: 0 2px 0 0;
 	right: 100%;
-
-	@include transform(translateY(-50%));
-
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 	top: 50%;
 }
 
@@ -171,9 +170,8 @@
 .dropdown-menu-right-side-middle {
 	left: 100%;
 	margin: 0 0 0 2px;
-
-	@include transform(translateY(-50%));
-
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
 	top: 50%;
 }
 
@@ -188,9 +186,8 @@
 	bottom: 100%;
 	left: 50%;
 	margin-bottom: 2px;
-
-	@include transform(translateX(-50%));
-
+	-ms-transform: translateX(-50%);
+	transform: translateX(-50%);
 	top: auto;
 }
 
@@ -328,7 +325,8 @@
 	.dropdown-menu-right-side-middle,
 	.dropdown-menu-top-center {
 		@media screen and (max-width: $grid-float-breakpoint-max) {
-			@include transform(none);
+			-ms-transform: none;
+			transform: none;
 		}
 	}
 }

--- a/src/scss/lexicon-base/_icons.scss
+++ b/src/scss/lexicon-base/_icons.scss
@@ -82,8 +82,8 @@ a.collapse-icon {
 	.collapse-icon-open {
 		margin-top: 0;
 		top: 50%;
-
-		@include transform(translateY(-50%));
+		-ms-transform: translateY(-50%);
+		transform: translateY(-50%);
 	}
 }
 

--- a/src/scss/lexicon-base/_list-group.scss
+++ b/src/scss/lexicon-base/_list-group.scss
@@ -329,9 +329,8 @@ button.list-group-heading,
 		.dropdown-menu {
 			left: 50%;
 			right: auto;
-
-			@include transform(translateX(-50%));
-
+			-ms-transform: translateX(-50%);
+			transform: translateX(-50%);
 			top: 100%;
 		}
 

--- a/src/scss/lexicon-base/_loaders.scss
+++ b/src/scss/lexicon-base/_loaders.scss
@@ -2,8 +2,7 @@
 
 .loading-icon,
 .loadingmask-message .loadingmask-message-content {
-	@include animation(loading-icon 1.7s infinite ease);
-
+	animation: loading-icon 1.7s infinite ease;
 	border-radius: 50%;
 	display: block;
 	font-size: 16px;
@@ -26,11 +25,11 @@
 	}
 }
 
-@include keyframes(loading-icon) {
+@keyframes loading-icon {
 	0% {
 		@include trailing-shadow(0, -0.83em, $loading-icon-color);
 
-		@include transform(rotate(0));
+		transform: rotate(0);
 	}
 
 	2%, 96% {
@@ -69,7 +68,7 @@
 	100% {
 		@include trailing-shadow(0, -0.83em);
 
-		@include transform(rotate(360deg));
+		transform: rotate(360deg);
 	}
 }
 
@@ -115,29 +114,55 @@
 }
 
 @keyframes loading-icon-linear {
-  0% {
-	transform: rotate(0deg);
-  }
+	0% {
+		transform: rotate(0deg);
+	}
 
-  10.99% {
-  	border-bottom-color: transparent;
-  }
+	10.99% {
+		border-bottom-color: transparent;
+	}
 
-  11% {
-  	border-bottom-color: $loading-icon-linear-color;
-  }
+	11% {
+		border-bottom-color: $loading-icon-linear-color;
+	}
 
-  66% {
-	border-bottom-color: $loading-icon-linear-color;
-  }
+	66% {
+		border-bottom-color: $loading-icon-linear-color;
+	}
 
-  66.6% {
-	border-bottom-color: transparent;
-  }
+	66.6% {
+		border-bottom-color: transparent;
+	}
 
-  66.6%, 100% {
-	transform: rotate(360deg);
-  }
+	66.6%, 100% {
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes loading-icon-linear {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	10.99% {
+		border-bottom-color: transparent;
+	}
+
+	11% {
+		border-bottom-color: $loading-icon-linear-color;
+	}
+
+	66% {
+		border-bottom-color: $loading-icon-linear-color;
+	}
+
+	66.6% {
+		border-bottom-color: transparent;
+	}
+
+	66.6%, 100% {
+		transform: rotate(360deg);
+	}
 }
 
 @keyframes loading-icon-spin {

--- a/src/scss/lexicon-base/_modals.scss
+++ b/src/scss/lexicon-base/_modals.scss
@@ -97,9 +97,7 @@
 		border-width: 0;
 		color: #000;
 		cursor: pointer;
-
-		@include opacity(0.2);
-
+		opacity: 0.2;
 		padding: 0;
 
 		&:focus,
@@ -107,8 +105,7 @@
 			background-color: transparent;
 			border-width: 0;
 			color: #000;
-
-			@include opacity(0.5);
+			opacity: 0.5;
 		}
 	}
 
@@ -227,13 +224,12 @@
 	}
 
 	.close {
+		opacity: 0.5;
 		text-shadow: 0 1px 0 $modal-inverse-header-border-color;
-
-		@include opacity(0.5);
 
 		&:focus,
 		&:hover {
-			@include opacity(1);
+			opacity: 1;
 		}
 	}
 

--- a/src/scss/lexicon-base/_nameplates.scss
+++ b/src/scss/lexicon-base/_nameplates.scss
@@ -87,9 +87,8 @@
 			position: absolute;
 			right: 5px;
 			text-align: left;
-
-			@include transform(translateY(-50%));
-
+			-ms-transform: translateY(-50%);
+			transform: translateY(-50%);
 			top: 50%;
 		}
 	}

--- a/src/scss/lexicon-base/_nav-tabs.scss
+++ b/src/scss/lexicon-base/_nav-tabs.scss
@@ -1,22 +1,22 @@
-@include keyframes(slideIn) {
+@keyframes slideIn {
 	0% {
-		@include transform(translateX(-100%));
+		transform: translateX(-100%);
 	}
 	100% {
-		@include transform(translateX(0));
+		transform: translateX(0);
 	}
 }
 
-@include keyframes(dropHeader) {
+@keyframes dropHeader {
 	0% {
-		@include transform(translateY(-100%));
+		transform: translateY(-100%);
 	}
 	100% {
-		@include transform(translateY(0));
+		transform: translateY(0);
 	}
 }
 
-@include keyframes(removeBorder) {
+@keyframes removeBorder {
 	0% {
 		border-bottom-color: #D8D8D8;
 	}
@@ -25,7 +25,7 @@
 	}
 }
 
-@include keyframes(fadeIn) {
+@keyframes fadeIn {
 	0% {
 		opacity: 0.25;
 	}
@@ -36,33 +36,27 @@
 
 @media screen and (max-width: $grid-float-breakpoint-max) {
 	.nav-tabs-scrollbar {
+		$ease-out-quint: cubic-bezier(0.230,  1.000, 0.320, 1.000);
 		$anim-key-frames: dropHeader 0.5s $ease-out-quint, removeBorder 0.75s $ease-out-quint;
-		$anim-delay: 0s, 0.45s;
 
-		@include prefixer(animation, $anim-key-frames, moz o webkit spec);
-		// @include prefixer(animation-fill-mode, both, moz o webkit spec); // breaks overflow scroll on safari and mobile safari
-		@include prefixer(animation-delay, $anim-delay, moz o webkit spec);
+		animation: $anim-key-frames;
+		animation-delay: 0s, 0.45s;
 		min-height: 54px;
 		overflow-x: scroll;
 		-webkit-overflow-scrolling: touch;
 
-		// &::-webkit-scrollbar {
-		// 	display: none;
-		// }
-
 		> .nav.nav-tabs,
 		> .nav.nav-pills {
-			@include prefixer(animation, slideIn 0.5s $ease-out-quint, moz o webkit spec);
-			@include prefixer(animation-delay, 0.4s, moz o webkit spec);
-			@include prefixer(animation-fill-mode, both, moz o webkit spec);
-			@include prefixer(animation-iteration-count, 1, moz o webkit spec);
-
+			animation: slideIn 0.5s $ease-out-quint;
+			animation-delay: 0.4s;
+			animation-fill-mode: both;
+			animation-iteration-count: 1;
 			white-space: nowrap;
 
 			> li {
-				@include prefixer(animation, fadeIn 0.5s ease-in, moz o webkit spec);
-				@include prefixer(animation-fill-mode, both, moz o webkit spec);
-				@include prefixer(animation-delay, 0.5s, moz o webkit spec);
+				animation: fadeIn 0.5s ease-in;
+				animation-fill-mode: both;
+				animation-delay: 0.5s;
 				float: none;
 				display: inline-block;
 			}

--- a/src/scss/lexicon-base/_navbar.scss
+++ b/src/scss/lexicon-base/_navbar.scss
@@ -92,11 +92,11 @@
 
 .basic-search-transition {
 	&:after {
-		@include transition(all 0.1s ease);
+		transition: all 0.1s ease;
 	}
 
 	.basic-search-slider {
-		@include transition(left 0.5s ease, right 0.5s ease);
+		transition: left 0.5s ease, right 0.5s ease;
 	}
 }
 

--- a/src/scss/lexicon-base/_progress-bars.scss
+++ b/src/scss/lexicon-base/_progress-bars.scss
@@ -86,9 +86,8 @@
 			font-family: 'fontawesome-alloy';
 			left: -12px;
 			position: absolute;
-
-			@include transform(translateY(-50%));
-
+			-ms-transform: translateY(-50%);
+			transform: translateY(-50%);
 			top: 50%;
 		}
 	}

--- a/src/scss/lexicon-base/_side-navigation.scss
+++ b/src/scss/lexicon-base/_side-navigation.scss
@@ -80,14 +80,14 @@
 	.sidenav-content,
 	.sidenav-menu,
 	.sidenav-menu-slider {
-		@include transition($sidenav-transition);
+		transition: $sidenav-transition;
 	}
 }
 
 // Simple Sidenav Transition
 
 .sidenav-transition {
-	@include transition($sidenav-transition);
+	transition: $sidenav-transition;
 }
 
 // Simple Sidenav

--- a/src/scss/lexicon-base/_sidebar.scss
+++ b/src/scss/lexicon-base/_sidebar.scss
@@ -66,7 +66,7 @@
 }
 
 .sidebar-transition {
-	@include transition(all 0.25s ease);
+	transition: all 0.25s ease;
 }
 
 // Skins

--- a/src/scss/lexicon-base/_simple-flexbox-grid.scss
+++ b/src/scss/lexicon-base/_simple-flexbox-grid.scss
@@ -1,63 +1,58 @@
 .flex-container {
-	@include display(flex);
-	@include flex-direction(row);
-	@include flex-flow(row);
-	@include flex-wrap(wrap);
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-direction: row;
+	flex-direction: row;
+	flex-flow: row;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
 }
 
 .flex-container-stacked {
-	@include flex-direction(column);
+	-ms-flex-direction: column;
+	flex-direction: column;
 }
 
 .flex-row-vertical {
-	@include display(flex);
-	@include flex-direction(column);
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-direction: column;
+	flex-direction: column;
 }
 
 .flex-item-expand {
-	@include flex(1);
-	@include flex-wrap(wrap);
-
+	-ms-flex: 1;
+	flex: 1;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
 	min-width: 0;
 }
 
 .flex-item-full {
-	@include flex(1 100%);
-	@include flex-wrap(wrap);
+	-ms-flex: 1 100%;
+	flex: 1 100%;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
 
 	+ .flex-item-expand {
-		@include flex-basis(auto);
+ 		-ms-flex-preferred-size: auto;
+ 		flex-basis: auto;
 	}
 }
 
 .flex-item-bottom {
-	@include align-self(flex-end);
-
-	// IE10, 11 Hack
-
-	@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-		max-width: 100%;
-	}
+	-ms-flex-item-align: end;
+	align-self: flex-end;
 }
 
 .flex-item-center {
-	@include align-self(center);
-
-	// IE10, 11 Hack
-
-	@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-		max-width: 100%;
-	}
+	-ms-flex-item-align: center;
+	align-self: center;
 }
 
 .flex-item-top {
-	@include align-self(flex-start);
-
-	// IE10, 11 Hack
-
-	@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-		max-width: 100%;
-	}
+	-ms-flex-item-align: start;
+	align-self: flex-start;
 }
 
 // Stacking Flex Container

--- a/src/scss/lexicon-base/_tables.scss
+++ b/src/scss/lexicon-base/_tables.scss
@@ -49,7 +49,8 @@ th {
 	}
 
 	.clamp-container {
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 
@@ -126,12 +127,14 @@ th {
 	}
 
 	thead .clamp-container {
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 
 	&.table-valign-middle thead .clamp-container,
 	.clamp-container {
-		@include transform(translateY(-50%));
+		-ms-transform: translateY(-50%);
+		transform: translateY(-50%);
 	}
 }
 
@@ -175,8 +178,8 @@ th {
 
 	.clamp-container {
 		bottom: $table-cell-padding;
-
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 
@@ -192,8 +195,8 @@ th {
 	}
 
 	.clamp-container {
-		@include transform(translateY(-50%));
-
+		-ms-transform: translateY(-50%);
+		transform: translateY(-50%);
 		top: auto;
 	}
 }
@@ -210,7 +213,8 @@ th {
 	}
 
 	.clamp-container {
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 
@@ -223,8 +227,8 @@ th {
 
 	tbody .clamp-container {
 		bottom: $table-cell-padding;
-
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 
@@ -234,8 +238,8 @@ th {
 	}
 
 	tbody .clamp-container {
-		@include transform(translateY(-50%));
-
+		-ms-transform: translateY(-50%);
+		transform: translateY(-50%);
 		top: auto;
 	}
 }
@@ -246,7 +250,8 @@ th {
 	}
 
 	tbody .clamp-container {
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 
@@ -261,7 +266,8 @@ th {
 	}
 
 	thead .clamp-container {
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }
 
@@ -275,8 +281,8 @@ th {
 
 	thead .clamp-container {
 		bottom: auto;
-
-		@include transform(translateY(-50%));
+		-ms-transform: translateY(-50%);
+		transform: translateY(-50%);
 	}
 }
 
@@ -290,7 +296,7 @@ th {
 
 	thead .clamp-container {
 		bottom: auto;
-
-		@include transform(none);
+		-ms-transform: none;
+		transform: none;
 	}
 }

--- a/src/scss/lexicon-base/_timelines.scss
+++ b/src/scss/lexicon-base/_timelines.scss
@@ -61,9 +61,8 @@
 		left: -($timeline-inner-spacing - $timeline-border-modifier);
 		position: absolute;
 		top: 50%;
-
-		@include transform(translate(-50%, -50%));
-
+		-ms-transform: translate(-50%, -50%);
+		transform: translate(-50%, -50%);
 		z-index: 1;
 	}
 }
@@ -106,6 +105,7 @@
 				position: absolute;
 				text-align: right;
 				top: 50%;
+				-ms-transform: translateY(-50%);
 				transform: translateY(-50%);
 				width: 100%;
 			}

--- a/src/scss/lexicon-base/_toggle-switch.scss
+++ b/src/scss/lexicon-base/_toggle-switch.scss
@@ -144,7 +144,7 @@ input.toggle-switch {
 		.toggle-switch-icon,
 		.toggle-switch-handle:after,
 		.toggle-switch-handle:before {
-			@include transition(all 100ms ease-in);
+			transition: all 100ms ease-in;
 		}
 	}
 }

--- a/src/scss/lexicon-base/main.scss
+++ b/src/scss/lexicon-base/main.scss
@@ -1,7 +1,5 @@
 @import "../bootstrap/bootstrap";
 
-@import "bourbon";
-
 @import "mixins";
 
 @import "lexicon";

--- a/src/scss/lexicon-base/mixins/_simple-flexbox-grid.scss
+++ b/src/scss/lexicon-base/mixins/_simple-flexbox-grid.scss
@@ -4,8 +4,8 @@
  */
 
 @mixin break-flex-item() {
-	@include flex-basis(auto);
-
+	-ms-flex-preferred-size: auto;
+	flex-basis: auto;
 	width: 100%;
 }
 
@@ -15,9 +15,11 @@
  */
 
 @mixin stack-flex-container() {
-	@include flex-direction(column);
+	-ms-flex-direction: column;
+	flex-direction: column;
 
 	.flex-item-full {
-		@include flex-basis(auto);
+ 		-ms-flex-preferred-size: auto;
+ 		flex-basis: auto;
 	}
 }

--- a/src/scss/lexicon-base/mixins/_timelines.scss
+++ b/src/scss/lexicon-base/mixins/_timelines.scss
@@ -17,8 +17,8 @@
 	.timeline-increment-icon {
 		left: auto;
 		right: -($timeline-inner-spacing + $timeline-border-modifier);
-
-		@include transform(translate(50%, -50%));
+		-ms-transform: translate(50%, -50%);
+		transform: translate(50%, -50%);
 	}
 }
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -3,8 +3,6 @@
 @import "bootstrap/variables";
 @import "bootstrap/mixins";
 
-@import "bourbon";
-
 @import "lexicon-base/variables";
 @import "lexicon-base/mixins";
 


### PR DESCRIPTION
Hey @natecavanaugh, I left the -ms-prefix on the transform properties that aren't inside animations so it will still work in ie9. It will be one less headache if someone chooses to make Lexicon work with ie9.

I was also able to remove the ie10 and ie11 flexbox hacks by not using Bourbon's flexbox mixins.