### PR TITLE
Fix: Word-wrap should work on card-col-content

### DIFF
--- a/src/scss/lexicon-base/_cards.scss
+++ b/src/scss/lexicon-base/_cards.scss
@@ -51,7 +51,7 @@
 	max-width: 10px;
 	position: relative;
 	width: auto;
-	word-break: break-all \ ; // IE 8, 9
+	word-break: break-all \9; // IE 8, 9
 	word-wrap: break-word;
 }
 


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/cards/#horizontal-cards-with-fixed-width-content