### PR TITLE
Breaking: Reduce number of selectors in management bar

### DIFF
--- a/src/scss/atlas-theme/_management-bar.scss
+++ b/src/scss/atlas-theme/_management-bar.scss
@@ -17,64 +17,34 @@
 	}
 }
 
-.management-bar-header,
-.management-bar-header-right {
-	> .checkbox,
-	> .radio {
-		@media (min-width: $grid-float-breakpoint) {
-			padding-bottom: 20px;
-			padding-top: 20px;
-		}
+.management-bar-header > .checkbox,
+.management-bar-header > .radio,
+.management-bar-header-right > .checkbox,
+.management-bar-header-right > .radio,
+.management-bar-nav > li > .checkbox,
+.management-bar-nav > li > .radio {
+	@media (min-width: $grid-float-breakpoint) {
+		padding-bottom: 20px;
+		padding-top: 20px;
 	}
 }
 
-.management-bar-nav {
-	> li {
-		> .management-bar-text {
-			padding: 14px 15px;
-
-			@media (min-width: $grid-float-breakpoint) {
-				padding: 19px 15px;
-			}
+.management-bar-nav > li,
+.management-bar-collapse .management-bar-nav > li {
+	> a,
+	> span {
+		@media (min-width: $grid-float-breakpoint) {
+			padding-bottom: $management-bar-desktop-padding-vertical;
+			padding-top: $management-bar-desktop-padding-vertical;
 		}
 	}
 }
 
 .management-bar-no-collapse .management-bar-nav {
-	> li {
-		> a {
-			padding-bottom: 12px;
-			padding-top: 12px;
-
-			@media (min-width: $grid-float-breakpoint) {
-				padding-bottom: 16px;
-				padding-top: 16px;
-			}
-		}
-
-		> .checkbox,
-		> .radio {
-			@media (min-width: $grid-float-breakpoint) {
-				padding-bottom: 20px;
-				padding-top: 20px;
-			}
-		}
-	}
-
 	.open .dropdown-menu {
 		&:after,
 		&:before {
 			display: block;
-		}
-	}
-}
-
-.management-bar-toggle-link {
-	&.management-bar-toggle {
-		padding: 14px 15px;
-
-		@media (min-width: $grid-float-breakpoint) {
-			padding: $management-bar-padding-vertical $management-bar-padding-horizontal;
 		}
 	}
 }
@@ -133,18 +103,17 @@
 .management-bar-default {
 	.btn-default,
 	.nav > li > .btn-default {
+		border-color: $management-bar-default-btn-default-border;
+
 		&:focus,
 		&:hover {
+			background-color: $management-bar-default-btn-default-bg;
 			border-color: $management-bar-default-btn-default-border;
 		}
 
 		&:active,
-		&:active:focus,
-		&.active,
-		&.active:focus,
-		&.active:hover {
+		&.active {
 			background-color: $management-bar-default-btn-default-border;
-			border-color: $management-bar-default-btn-default-border;
 		}
 	}
 
@@ -152,20 +121,11 @@
 	.nav > .open > .btn-default {
 		&,
 		&:active,
-		&:active:focus,
+		&.active,
 		&:focus,
 		&:hover {
 			background-color: $management-bar-default-btn-default-border;
-			border-color: $management-bar-default-btn-default-border;
-		}
-	}
-
-	.open > .btn-default.dropdown-toggle {
-		&,
-		&:focus,
-		&:hover,
-		&.focus {
-			box-shadow: none;
+			color: $management-bar-default-btn-default-color;
 		}
 	}
 }

--- a/src/scss/atlas-theme/variables/_management-bar.scss
+++ b/src/scss/atlas-theme/variables/_management-bar.scss
@@ -5,9 +5,13 @@ $management-bar-border-right-width: 0 !default;
 $management-bar-border-top-width: 0 !default;
 
 $management-bar-height: $navbar-height !default;
+$management-bar-btn-padding-vertical: ($management-bar-height - $icon-monospaced-size - ($btn-border-width * 2)) / 2 !default;
+
 $management-bar-desktop-height: $navbar-desktop-height !default;
+$management-bar-desktop-padding-horizontal: $navbar-desktop-padding-horizontal !default;
+$management-bar-desktop-padding-vertical: 19px !default;
 $management-bar-desktop-btn-padding-horizontal: $navbar-desktop-padding-horizontal !default;
-$management-bar-desktop-btn-padding-vertical: ($management-bar-desktop-height - $icon-monospaced-size - 2) / 2 !default;
+$management-bar-desktop-btn-padding-vertical: ($management-bar-desktop-height - $icon-monospaced-size - ($btn-border-width * 2)) / 2 !default;
 
 // Skin
 

--- a/src/scss/lexicon-base/_management-bar.scss
+++ b/src/scss/lexicon-base/_management-bar.scss
@@ -1,8 +1,18 @@
 .management-bar {
-	@extend .navbar;
-
+	border-color: transparent;
 	border-style: solid;
 	border-width: $management-bar-border-width;
+
+	@include clearfix;
+
+	margin-bottom: $navbar-margin-bottom;
+	min-height: $management-bar-height;
+	position: relative;
+
+
+	@media (min-width: $grid-float-breakpoint) {
+		border-radius: $navbar-border-radius;
+	}
 
 	.checkbox,
 	.radio {
@@ -42,6 +52,24 @@
 
 // management bar headers
 
+.container,
+.container-fluid {
+	> .management-bar-header,
+	> .management-bar-collapse {
+		margin-right: -$management-bar-padding-horizontal;
+		margin-left:  -$management-bar-padding-horizontal;
+
+		@media (min-width: $grid-float-breakpoint) {
+			margin-right: 0;
+			margin-left:  0;
+		}
+	}
+}
+
+.container-fluid-1280 .management-bar-header-right {
+	margin-right: 0;
+}
+
 .management-bar-header,
 .management-bar-header-right {
 	> .checkbox,
@@ -52,12 +80,15 @@
 }
 
 .management-bar-header {
-	@extend .navbar-header;
+	@include clearfix;
 
 	float: left;
 }
 
 .management-bar-header-right {
+	float: right;
+	margin-right: $management-bar-padding-horizontal;
+
 	> a {
 		display: block;
 		float: left;
@@ -66,18 +97,25 @@
 }
 
 .management-bar-header-item {
-	@extend .navbar-brand;
-}
+	float: left;
+	height: $management-bar-height;
+	padding: $management-bar-padding-vertical $management-bar-padding-horizontal;
 
-.management-bar-header-right {
-	@extend .navbar-header-right;
+	&:hover,
+	&:focus {
+		text-decoration: none;
+	}
 
-	float: right;
-	margin-right: $management-bar-padding-horizontal;
-}
+	> img {
+		display: block;
+	}
 
-.container-fluid-1280 .management-bar-header-right {
-	margin-right: 0;
+	.management-bar > .container &,
+	.management-bar > .container-fluid & {
+		@media (min-width: $grid-float-breakpoint) {
+			margin-left: -$management-bar-padding-horizontal;
+		}
+	}
 }
 
 .management-bar-item-title {
@@ -94,9 +132,25 @@
 }
 
 .management-bar-toggle {
-	@extend .navbar-toggle;
+	background-color: transparent;
+	background-image: none;
+	border-radius: $border-radius-base;
+	border: 1px solid transparent;
+	float: right;
+	margin-right: $management-bar-padding-horizontal;
+
+	@include navbar-vertical-align(34px);
+
+	padding: 9px 10px;
+	position: relative;
+
+	@media (min-width: $grid-float-breakpoint) {
+		display: none;
+	}
 
 	&:focus {
+		outline: 0;
+
 		@include tab-focus;
 	}
 }
@@ -118,13 +172,27 @@
 }
 
 .management-bar-toggle-left {
-	@extend .navbar-toggle-left;
+	float: left;
+	margin: floor(($navbar-height - $input-height-base) / 2) $navbar-padding-horizontal;
+	padding: $padding-base-vertical 10px;
+}
+
+.management-bar-default .management-bar-toggle-left {
+	color: $management-bar-default-link-active-color;
 }
 
 // management bar collapse
 
 .management-bar-collapse {
-	@extend .navbar-collapse;
+	-webkit-overflow-scrolling: touch;
+	border-top: 1px solid transparent;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+
+	@include clearfix;
+
+	overflow-x: visible;
+	padding-left:  $management-bar-padding-horizontal;
+	padding-right: $management-bar-padding-horizontal;
 
 	@media (max-width: $grid-float-breakpoint-max) {
 		background-color: $management-bar-collapse-bg;
@@ -140,11 +208,111 @@
 	}
 
 	@media (min-width: $grid-float-breakpoint) {
+		border-top: 0;
+		box-shadow: none;
 		clear: none;
 		margin-top: 0;
 		padding-left: 0;
 		padding-right: 0;
 		position: static;
+		width: auto;
+	}
+
+	&.collapse {
+		@media (min-width: $grid-float-breakpoint) {
+			display: block !important;
+			height: auto !important;
+			overflow: visible !important;
+			padding-bottom: 0;
+		}
+	}
+
+	&.in {
+		overflow-y: auto;
+
+		@media (min-width: $grid-float-breakpoint) {
+			overflow-y: visible;
+		}
+	}
+}
+
+.management-bar-default {
+	.management-bar-collapse {
+		border-color: $management-bar-default-border;
+	}
+}
+
+.management-bar-collapse .management-bar-nav {
+	> li > a,
+	> li > span {
+		padding-bottom: 10px;
+		padding-top: 10px;
+
+		@media (min-width: $grid-float-breakpoint) {
+			padding-bottom: $management-bar-padding-vertical;
+			padding-top: $management-bar-padding-vertical;
+		}
+	}
+}
+
+.management-bar-nav {
+	margin: ($management-bar-padding-vertical / 2) (-$management-bar-padding-horizontal);
+
+	@media (min-width: $grid-float-breakpoint) {
+		float: left;
+		margin: 0;
+	}
+
+	> li {
+		@media (min-width: $grid-float-breakpoint) {
+			float: left;
+		}
+
+		> a,
+		> span {
+			display: inline-block;
+			padding: $management-bar-padding-vertical $management-bar-padding-horizontal;
+		}
+
+		> .checkbox {
+			padding-bottom: $management-bar-padding-vertical;
+			padding-left: $management-bar-padding-horizontal;
+			padding-top: $management-bar-padding-vertical;
+		}
+
+		> .dropdown-menu {
+			@include border-top-radius(0);
+
+			margin-top: 0;
+		}
+	}
+
+	.open .dropdown-menu {
+		@media (max-width: $grid-float-breakpoint-max) {
+			background-color: transparent;
+			border: 0;
+			box-shadow: none;
+			float: none;
+			margin-top: 0;
+			position: static;
+			width: auto;
+		}
+
+		> li > a,
+		.dropdown-header {
+			@media (max-width: $grid-float-breakpoint-max) {
+				padding: 5px 15px 5px 25px;
+			}
+		}
+
+		> li > a {
+			&:hover,
+			&:focus {
+				@media (max-width: $grid-float-breakpoint-max) {
+					background-image: none;
+				}
+			}
+		}
 	}
 }
 
@@ -159,11 +327,6 @@
 
 			&:first-child {
 				margin-left: 0;
-			}
-
-			> a {
-				padding-bottom: $management-bar-padding-vertical;
-				padding-top: $management-bar-padding-vertical;
 			}
 		}
 
@@ -187,56 +350,82 @@
 	}
 }
 
-.management-bar-nav {
-	@extend .navbar-nav;
+.management-bar-default {
+	.navbar-nav {
+		> li > a {
+			color: $management-bar-default-link-color;
 
-	> li {
-		> .checkbox {
-			padding-bottom: $management-bar-padding-vertical;
-			padding-left: $management-bar-padding-horizontal;
-			padding-top: $management-bar-padding-vertical;
+			&:hover,
+			&:focus {
+				color: $management-bar-default-link-hover-color;
+				background-color: $management-bar-default-link-hover-bg;
+			}
 		}
 
-		.management-bar-text {
-			display: inline-block;
-			padding: $management-bar-padding-vertical $management-bar-padding-horizontal;
+		> .active > a {
+			&,
+			&:hover,
+			&:focus {
+				color: $management-bar-default-link-active-color;
+				background-color: $management-bar-default-link-active-bg;
+			}
+		}
+
+		> .disabled > a {
+			&,
+			&:hover,
+			&:focus {
+				color: $management-bar-default-link-disabled-color;
+				background-color: $management-bar-default-link-disabled-bg;
+			}
+		}
+	}
+
+	.navbar-nav {
+		> .open > a {
+			&,
+			&:hover,
+			&:focus {
+				background-color: $management-bar-default-link-active-bg;
+				color: $management-bar-default-link-active-color;
+			}
+		}
+
+		@media (max-width: $grid-float-breakpoint-max) {
+			.open .dropdown-menu {
+				> li > a {
+					color: $management-bar-default-link-color;
+
+					&:hover,
+					&:focus {
+						color: $management-bar-default-link-hover-color;
+						background-color: $management-bar-default-link-hover-bg;
+					}
+				}
+
+				> .active > a {
+					&,
+					&:hover,
+					&:focus {
+						color: $management-bar-default-link-active-color;
+						background-color: $management-bar-default-link-active-bg;
+					}
+				}
+
+				> .disabled > a {
+					&,
+					&:hover,
+					&:focus {
+						color: $management-bar-default-link-disabled-color;
+						background-color: $management-bar-default-link-disabled-bg;
+					}
+				}
+			}
 		}
 	}
 }
 
 // Management Bar Skins
-
-.management-bar {
-	.btn-danger,
-	.nav > li > .btn-danger {
-		@include button-variant($btn-danger-color, $btn-danger-bg, $btn-danger-border);
-	}
-
-	.btn-default,
-	.nav > li > .btn-default {
-		@include button-variant($btn-default-color, $btn-default-bg, $btn-default-border);
-	}
-
-	.btn-info,
-	.nav > li > .btn-info {
-		@include button-variant($btn-info-color, $btn-info-bg, $btn-info-border);
-	}
-
-	.btn-primary,
-	.nav > li > .btn-primary {
-		@include button-variant($btn-primary-color, $btn-primary-bg, $btn-primary-border);
-	}
-
-	.btn-success,
-	.nav > li > .btn-success {
-		@include button-variant($btn-success-color, $btn-success-bg, $btn-success-border);
-	}
-
-	.btn-warning,
-	.nav > li > .btn-warning {
-		@include button-variant($btn-warning-color, $btn-warning-bg, $btn-warning-border);
-	}
-}
 
 .management-bar-default {
 	background-color: $management-bar-default-bg;
@@ -302,22 +491,19 @@
 .management-bar-default {
 	.btn-default,
 	.nav > li > .btn-default {
-		@include button-variant($management-bar-default-btn-default-color, $management-bar-default-btn-default-bg, $management-bar-default-btn-default-border);
-	}
+		background-color: $management-bar-default-btn-default-bg;
+		color: $management-bar-default-btn-default-color;
 
-	.nav > .open > .btn-default {
-		background-color: darken($management-bar-default-btn-default-bg, 10%);
-		border-color: darken($management-bar-default-btn-default-border, 12%);
-		box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-	}
-
-	.open > .btn-default.dropdown-toggle {
-		&,
 		&:focus,
-		&:hover,
-		&.focus {
-			box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+		&:hover {
+			background-color: darken($management-bar-default-btn-default-bg, 10%);
+			border-color: darken($management-bar-default-btn-default-border, 12%);
 			color: $management-bar-default-btn-default-color;
+		}
+
+		&:active,
+		&.active {
+			background-color: darken($management-bar-default-btn-default-bg, 10%);
 		}
 	}
 }


### PR DESCRIPTION
Hey @natecavanaugh, management-bar shouldn't extend navbar anymore and I removed contextual buttons (btn-primary, btn-danger, btn-warning, etc) from management bar (breaking). The button-variant mixin from Bootstrap was adding a lot of selectors. I was able to reduce Lexicon Base's management-bar from 747 to 135 selectors.