### PR TITLE
Fix: Collapsible search should transition for browsers that support c…

### DIFF
--- a/src/js/collapsible-search.js
+++ b/src/js/collapsible-search.js
@@ -1,6 +1,4 @@
 +function($) {
-	var SUPPORTS_TRANSITIONS = $.support.transition;
-
 	var CollapsibleSearch = function(element) {
 		var instance = this;
 
@@ -39,14 +37,14 @@
 				basicSearch.trigger('closed.lexicon.collapsible.search');
 			};
 
-			if (SUPPORTS_TRANSITIONS) {
+			if ($.support.transition) {
 				basicSearchSlider.one('bsTransitionEnd', $.proxy(complete, instance))
 					.emulateTransitionEnd(CollapsibleSearch.TRANSITION_DURATION);
 			}
 
 			basicSearch.addClass('basic-search-transition').removeClass('open');
 
-			if (!SUPPORTS_TRANSITIONS) {
+			if (!$.support.transition) {
 				complete.call(instance);
 			}
 			else {
@@ -86,14 +84,14 @@
 				if (!basicSearch.hasClass('open')) {
 					event.preventDefault();
 
-					if (SUPPORTS_TRANSITIONS) {
+					if ($.support.transition) {
 						basicSearchSlider.one('bsTransitionEnd', $.proxy(complete, instance))
 							.emulateTransitionEnd(CollapsibleSearch.TRANSITION_DURATION);
 					}
 
 					basicSearch.addClass('basic-search-transition').addClass('open');
 
-					if (!SUPPORTS_TRANSITIONS) {
+					if (!$.support.transition) {
 						complete.call(instance);
 					}
 				}


### PR DESCRIPTION
…ss transitions

Hey @natecavanaugh, $.support.transition is undefined when the collapsible search plugin first runs. I wasn't sure how to get around that other than using a timeout. I decided to go back to using $.support.transition directly rather than storing it in a variable.