### PR TITLE
Update: Undo border styles when using nav-tabs in navbar

### DIFF
--- a/src/scss/lexicon-base/_navbar.scss
+++ b/src/scss/lexicon-base/_navbar.scss
@@ -288,9 +288,25 @@
 
 // Navbar
 
-.navbar .container-fluid-1280 {
-	padding-left: 0;
-	padding-right: 0;
+.navbar {
+	.container-fluid-1280 {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.nav-tabs {
+		border-width: 0;
+
+		> li > a {
+			&,
+			&:focus,
+			&:hover {
+				border-radius: 0;
+				border-width: 0;
+				margin-right: 0;
+			}
+		}
+	}
 }
 
 @if (variable-exists(atlas-theme)) {


### PR DESCRIPTION
Hey @natecavanaugh, We have an instance in portal where we are putting nav-tabs inside a navbar (edit forms sidebar), throwing off the navbar styles. I thought it's better to add a reset in Lexicon since there could be other places we do that.