### PR TITLE
Fix: Label icon styles bleed into checkbox-card

### DIFF
--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -5,7 +5,7 @@ input[type="radio"] {
 
 label,
 .control-label {
-	.lexicon-icon {
+	> .lexicon-icon {
 		vertical-align: baseline;
 	}
 


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/badges-and-labels/#sticker-static