### PR TITLE
Fix: Really long text inside fieldsets should break to new line

### DIFF
--- a/src/content/form_elements.html
+++ b/src/content/form_elements.html
@@ -325,6 +325,11 @@ Checkboxes unable to be styled in IE with this method. -->
 		<form style="margin-bottom: 15px;">
 			<fieldset disabled>
 				<div class="form-group">
+					<label>Use fieldset to group related elements in a form and ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual
+						<input class="form-control" type="text" value="Plunger pot, extra siphon latte">
+					</label>
+				</div>
+				<div class="form-group">
 					<label for="disabledTextInput">Disabled input</label>
 					<input class="form-control" id="disabledTextInput" type="text" value="Plunger pot, extra siphon latte">
 				</div>

--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -3,6 +3,14 @@ input[type="radio"] {
 	cursor: pointer;
 }
 
+fieldset {
+	word-wrap: break-word;
+
+	@-moz-document url-prefix() { // FF Fieldset workaround
+		display: table-cell;
+	}
+}
+
 label,
 .control-label {
 	.lexicon-icon {


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/form-elements/#disabled-fieldset

Hey @natecavanaugh, Really long text inside fieldsets should break to a new line. This is a workaround for a FF browser bug. I visited this a while ago in FF Developer Edition and noticed it was behaving like webkit, but now FF and developer edition are behaving the same.