### PR TITLE
Fix: Atlas mobile navbar search close button shouldn't overlap input …

### DIFF
--- a/src/scss/lexicon-base/_navbar.scss
+++ b/src/scss/lexicon-base/_navbar.scss
@@ -206,7 +206,7 @@
 			overflow: hidden;
 			position: relative;
 			top: $navbar-border-bottom-width;
-			z-index: 4;
+			z-index: $zindex-basic-search-close;
 		}
 
 		&.focus:after {


### PR DESCRIPTION
…border

http://liferay.github.io/lexicon/content/navbar/#alternate-navbar-toggle-style