### PR TITLE
Fix: Nameplates interpolate $screen-xs-max variable inside mixin name…

### DIFF
--- a/src/scss/lexicon-base/_nameplates.scss
+++ b/src/scss/lexicon-base/_nameplates.scss
@@ -95,7 +95,7 @@
 // Nameplate Label Helpers
 
 .nameplate-label-autofit-xs-max {
-	@include nameplate-label-autofit('max-width: $screen-xs-max');
+	@include nameplate-label-autofit('max-width: #{$screen-xs-max}');
 }
 
 @if not ($nameplate-label-border-radius == $nameplate-label-circle-border-radius) {


### PR DESCRIPTION
…plate-label-autofit