### PR TITLE
Update: Tabular-list-group move bg-color from rows to cells

### DIFF
--- a/src/scss/lexicon-base/_list-group.scss
+++ b/src/scss/lexicon-base/_list-group.scss
@@ -250,6 +250,7 @@ button.list-group-heading {
 	width: 100%;
 
 	.list-group-item {
+		background-color: transparent; // Chrome rendering issue with responsive-tables and td position relative
 		display: table-row;
 		height: $tabular-list-group-item-height;
 		padding: 0;
@@ -260,10 +261,20 @@ button.list-group-heading {
 				border-top-width: $tabular-list-group-border-width;
 			}
 		}
+
+		// Chrome rendering issue with responsive-tables and td position relative
+
+		&.active {
+			.list-group-item-content,
+			.list-group-item-field {
+				background-color: $list-group-active-bg;
+			}
+		}
 	}
 
 	.list-group-item-content,
 	.list-group-item-field {
+		background-color: $list-group-bg; // Chrome rendering issue with responsive-tables and td position relative
 		border: $tabular-list-group-border-width solid $list-group-border;
 		border-left-width: 0;
 		border-right-width: 0;


### PR DESCRIPTION
Hey Nate,

This is a fix for tabular-list-group background colors rendering weird in Chrome. It only happens when it's inside a collapsible panel. I think it's related to the responsive table background issue we were having before.

<img width="343" alt="tabular-list-group" src="https://cloud.githubusercontent.com/assets/788266/21117899/770b4f6a-c070-11e6-8967-025aa3e23a37.png">
