### PR TITLE
Update: Badges check for atlas-theme instead of badge-default-bg sinc…

### DIFF
--- a/src/scss/lexicon-base/_badges.scss
+++ b/src/scss/lexicon-base/_badges.scss
@@ -83,7 +83,7 @@
 	background-color: $brand-danger;
 }
 
-@if (variable-exists(badge-default-bg)) {
+@if (variable-exists(atlas-theme)) {
 	.badge-default {
 		background-color: $badge-default-bg;
 		color: $badge-default-color;


### PR DESCRIPTION
…e there are other variables in the block