### PR TITLE
Update: Bootstrap to 3.3.7

### DIFF
--- a/src/scss/bootstrap/_breadcrumbs.scss
+++ b/src/scss/bootstrap/_breadcrumbs.scss
@@ -14,7 +14,9 @@
     display: inline-block;
 
     + li:before {
-      content: "#{$breadcrumb-separator}\00a0"; // Unicode space added since inline-block means non-collapsing white-space
+      // [converter] Workaround for https://github.com/sass/libsass/issues/1115
+      $nbsp: "\00a0";
+      content: "#{$breadcrumb-separator}#{$nbsp}"; // Unicode space added since inline-block means non-collapsing white-space
       padding: 0 5px;
       color: $breadcrumb-color;
     }

--- a/src/scss/bootstrap/_button-groups.scss
+++ b/src/scss/bootstrap/_button-groups.scss
@@ -59,7 +59,7 @@
     @include border-right-radius(0);
   }
 }
-// Need .dropdown-toggle since :last-child doesn't apply given a .dropdown-menu immediately after it
+// Need .dropdown-toggle since :last-child doesn't apply, given that a .dropdown-menu is used immediately after it
 .btn-group > .btn:last-child:not(:first-child),
 .btn-group > .dropdown-toggle:not(:first-child) {
   @include border-left-radius(0);
@@ -173,12 +173,12 @@
     border-radius: 0;
   }
   &:first-child:not(:last-child) {
-    border-top-right-radius: $btn-border-radius-base;
+    @include border-top-radius($btn-border-radius-base);
     @include border-bottom-radius(0);
   }
   &:last-child:not(:first-child) {
-    border-bottom-left-radius: $btn-border-radius-base;
     @include border-top-radius(0);
+    @include border-bottom-radius($btn-border-radius-base);
   }
 }
 .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {

--- a/src/scss/bootstrap/_carousel.scss
+++ b/src/scss/bootstrap/_carousel.scss
@@ -101,6 +101,7 @@
   color: $carousel-control-color;
   text-align: center;
   text-shadow: $carousel-text-shadow;
+  background-color: rgba(0, 0, 0, 0); // Fix IE9 click-thru bug
   // We can't have this transition here because WebKit cancels the carousel
   // animation if you trip this while in the middle of another animation.
 
@@ -240,18 +241,18 @@
     .glyphicon-chevron-right,
     .icon-prev,
     .icon-next {
-      width: 30px;
-      height: 30px;
-      margin-top: -15px;
-      font-size: 30px;
+      width: ($carousel-control-font-size * 1.5);
+      height: ($carousel-control-font-size * 1.5);
+      margin-top: ($carousel-control-font-size / -2);
+      font-size: ($carousel-control-font-size * 1.5);
     }
     .glyphicon-chevron-left,
     .icon-prev {
-      margin-left: -15px;
+      margin-left: ($carousel-control-font-size / -2);
     }
     .glyphicon-chevron-right,
     .icon-next {
-      margin-right: -15px;
+      margin-right: ($carousel-control-font-size / -2);
     }
   }
 

--- a/src/scss/bootstrap/_forms.scss
+++ b/src/scss/bootstrap/_forms.scss
@@ -132,6 +132,12 @@ output {
   // Placeholder
   @include placeholder;
 
+  // Unstyle the caret on `<select>`s in IE10+.
+  &::-ms-expand {
+    border: 0;
+    background-color: transparent;
+  }
+
   // Disabled and read-only inputs
   //
   // HTML5 says that controls under a fieldset > legend:first-child won't be
@@ -177,7 +183,7 @@ input[type="search"] {
 // set a pixel line-height that matches the given height of the input, but only
 // for Safari. See https://bugs.webkit.org/show_bug.cgi?id=139848
 //
-// Note that as of 8.3, iOS doesn't support `datetime` or `week`.
+// Note that as of 9.3, iOS doesn't support `week`.
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   input[type="date"],
@@ -431,10 +437,10 @@ input[type="checkbox"] {
 .has-feedback label {
 
   & ~ .form-control-feedback {
-     top: ($line-height-computed + 5); // Height of the `label` and its margin
+    top: ($line-height-computed + 5); // Height of the `label` and its margin
   }
   &.sr-only ~ .form-control-feedback {
-     top: 0;
+    top: 0;
   }
 }
 
@@ -595,7 +601,7 @@ input[type="checkbox"] {
   .form-group-lg {
     @media (min-width: $screen-sm-min) {
       .control-label {
-        padding-top: (($padding-large-vertical * $line-height-large) + 1);
+        padding-top: ($padding-large-vertical + 1);
         font-size: $font-size-large;
       }
     }

--- a/src/scss/bootstrap/_glyphicons.scss
+++ b/src/scss/bootstrap/_glyphicons.scss
@@ -34,8 +34,8 @@
 }
 
 // Individual icons
-.glyphicon-asterisk               { &:before { content: "\2a"; } }
-.glyphicon-plus                   { &:before { content: "\2b"; } }
+.glyphicon-asterisk               { &:before { content: "\002a"; } }
+.glyphicon-plus                   { &:before { content: "\002b"; } }
 .glyphicon-euro,
 .glyphicon-eur                    { &:before { content: "\20ac"; } }
 .glyphicon-minus                  { &:before { content: "\2212"; } }

--- a/src/scss/bootstrap/_input-groups.scss
+++ b/src/scss/bootstrap/_input-groups.scss
@@ -29,6 +29,10 @@
 
     width: 100%;
     margin-bottom: 0;
+
+    &:focus {
+      z-index: 3;
+    }
   }
 }
 
@@ -79,18 +83,18 @@
   text-align: center;
   background-color: $input-group-addon-bg;
   border: 1px solid $input-group-addon-border-color;
-  border-radius: $border-radius-base;
+  border-radius: $input-border-radius;
 
   // Sizing
   &.input-sm {
     padding: $padding-small-vertical $padding-small-horizontal;
     font-size: $font-size-small;
-    border-radius: $border-radius-small;
+    border-radius: $input-border-radius-small;
   }
   &.input-lg {
     padding: $padding-large-vertical $padding-large-horizontal;
     font-size: $font-size-large;
-    border-radius: $border-radius-large;
+    border-radius: $input-border-radius-large;
   }
 
   // Nuke default margins from checkboxes and radios to vertically center within.

--- a/src/scss/bootstrap/_jumbotron.scss
+++ b/src/scss/bootstrap/_jumbotron.scss
@@ -28,6 +28,8 @@
   .container &,
   .container-fluid & {
     border-radius: $border-radius-large; // Only round corners at higher resolutions if contained in a container
+    padding-left:  ($grid-gutter-width / 2);
+    padding-right: ($grid-gutter-width / 2);
   }
 
   .container {

--- a/src/scss/bootstrap/_modals.scss
+++ b/src/scss/bootstrap/_modals.scss
@@ -79,7 +79,7 @@
 .modal-header {
   padding: $modal-title-padding;
   border-bottom: 1px solid $modal-header-border-color;
-  min-height: ($modal-title-padding + $modal-title-line-height);
+  @include clearfix;
 }
 // Close icon
 .modal-header .close {

--- a/src/scss/bootstrap/_pagination.scss
+++ b/src/scss/bootstrap/_pagination.scss
@@ -40,7 +40,7 @@
   > li > span {
     &:hover,
     &:focus {
-      z-index: 3;
+      z-index: 2;
       color: $pagination-hover-color;
       background-color: $pagination-hover-bg;
       border-color: $pagination-hover-border;
@@ -52,7 +52,7 @@
     &,
     &:hover,
     &:focus {
-      z-index: 2;
+      z-index: 3;
       color: $pagination-active-color;
       background-color: $pagination-active-bg;
       border-color: $pagination-active-border;

--- a/src/scss/bootstrap/_panels.scss
+++ b/src/scss/bootstrap/_panels.scss
@@ -214,7 +214,7 @@
 }
 
 
-// Collapsable panels (aka, accordion)
+// Collapsible panels (aka, accordion)
 //
 // Wrap a series of panels in `.panel-group` to turn them into an accordion with
 // the help of our collapse JavaScript plugin.

--- a/src/scss/bootstrap/_scaffolding.scss
+++ b/src/scss/bootstrap/_scaffolding.scss
@@ -120,7 +120,7 @@ hr {
 
 // Only display content to screen readers
 //
-// See: http://a11yproject.com/posts/how-to-hide-content/
+// See: http://a11yproject.com/posts/how-to-hide-content
 
 .sr-only {
   position: absolute;

--- a/src/scss/bootstrap/_theme.scss
+++ b/src/scss/bootstrap/_theme.scss
@@ -1,6 +1,6 @@
 /*!
- * Bootstrap v3.3.5 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 

--- a/src/scss/bootstrap/_type.scss
+++ b/src/scss/bootstrap/_type.scss
@@ -207,7 +207,7 @@ dd {
     @include clearfix; // Clear the floated `dt` if an empty `dd` is present
   }
 
-  @media (min-width: $grid-float-breakpoint) {
+  @media (min-width: $dl-horizontal-breakpoint) {
     dt {
       float: left;
       width: ($dl-horizontal-offset - 20);

--- a/src/scss/bootstrap/_variables.scss
+++ b/src/scss/bootstrap/_variables.scss
@@ -116,7 +116,7 @@ $component-active-color:    #fff !default;
 //** Global background color for active items (e.g., navs or dropdowns).
 $component-active-bg:       $brand-primary !default;
 
-//** Width of the `border` for generating carets that indicator dropdowns.
+//** Width of the `border` for generating carets that indicate dropdowns.
 $caret-width-base:          4px !default;
 //** Carets increase slightly in size for larger components.
 $caret-width-large:         5px !default;
@@ -868,5 +868,7 @@ $blockquote-border-color:     $gray-lighter !default;
 $page-header-border-color:    $gray-lighter !default;
 //** Width of horizontal description list titles
 $dl-horizontal-offset:        $component-offset-horizontal !default;
+//** Point at which .dl-horizontal becomes horizontal
+$dl-horizontal-breakpoint:    $grid-float-breakpoint !default;
 //** Horizontal line color.
 $hr-border:                   $gray-lighter !default;

--- a/src/scss/bootstrap/bootstrap.scss
+++ b/src/scss/bootstrap/bootstrap.scss
@@ -1,6 +1,6 @@
 /*!
- * Bootstrap v3.3.5 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 

--- a/src/scss/bootstrap/mixins/_buttons.scss
+++ b/src/scss/bootstrap/mixins/_buttons.scss
@@ -42,12 +42,9 @@
   &.disabled,
   &[disabled],
   fieldset[disabled] & {
-    &,
     &:hover,
     &:focus,
-    &.focus,
-    &:active,
-    &.active {
+    &.focus {
       background-color: $background;
           border-color: $border;
     }

--- a/src/scss/bootstrap/mixins/_grid.scss
+++ b/src/scss/bootstrap/mixins/_grid.scss
@@ -6,8 +6,8 @@
 @mixin container-fixed($gutter: $grid-gutter-width) {
   margin-right: auto;
   margin-left: auto;
-  padding-left:  ($gutter / 2);
-  padding-right: ($gutter / 2);
+  padding-left:  floor(($gutter / 2));
+  padding-right: ceil(($gutter / 2));
   @include clearfix;
 }
 

--- a/src/scss/bootstrap/mixins/_hide-text.scss
+++ b/src/scss/bootstrap/mixins/_hide-text.scss
@@ -6,7 +6,7 @@
 //
 // Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
 
-// Deprecated as of v3.0.1 (will be removed in v4)
+// Deprecated as of v3.0.1 (has been removed in v4)
 @mixin hide-text() {
   font: 0/0 a;
   color: transparent;

--- a/src/scss/bootstrap/mixins/_tab-focus.scss
+++ b/src/scss/bootstrap/mixins/_tab-focus.scss
@@ -1,9 +1,9 @@
 // WebKit-style focus
 
 @mixin tab-focus() {
-  // Default
-  outline: thin dotted;
-  // WebKit
+  // WebKit-specific. Other browsers will keep their default outline style.
+  // (Initially tried to also force default via `outline: initial`,
+  // but that seems to erroneously remove the outline in Firefox altogether.)
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }

--- a/src/scss/bootstrap/mixins/_vendor-prefixes.scss
+++ b/src/scss/bootstrap/mixins/_vendor-prefixes.scss
@@ -1,7 +1,7 @@
 // Vendor Prefixes
 //
 // All vendor mixins are deprecated as of v3.2.0 due to the introduction of
-// Autoprefixer in our Gruntfile. They will be removed in v4.
+// Autoprefixer in our Gruntfile. They have been removed in v4.
 
 // - Animations
 // - Backface visibility
@@ -54,7 +54,7 @@
 // Prevent browsers from flickering when using CSS 3D transforms.
 // Default value is `visible`, but can be changed to `hidden`
 
-@mixin backface-visibility($visibility){
+@mixin backface-visibility($visibility) {
   -webkit-backface-visibility: $visibility;
      -moz-backface-visibility: $visibility;
           backface-visibility: $visibility;


### PR DESCRIPTION
Bootstrap's changes to:
src/scss/bootstrap/_breadcrumbs.scss
src/scss/bootstrap/_forms.scss
src/scss/bootstrap/_input-groups.scss
src/scss/bootstrap/_modals.scss
src/scss/bootstrap/_pagination.scss
shouldn't break anything in Lexicon Base or Atlas. We overwrite most of those changes made, the rest are bug fixes.