### PR TITLE
Update: Remove input label disabled opacity and rename input-disabled variables

### DIFF
--- a/src/scss/atlas-theme/variables/_forms.scss
+++ b/src/scss/atlas-theme/variables/_forms.scss
@@ -58,13 +58,10 @@ $input-box-shadow-focus: none !default;
 $input-color-placeholder: darken(#E4E9EC, 12%) !default;
 $input-color-placeholder-focus: $input-border-focus !default;
 
-// Deprecated `$input-border-disabled` as of v1.0.16 and will be removed in
-// v2.0.0 use `$input-disabled-border` instead
 $input-border-disabled: #CFD7DE !default;
-$input-disabled-border: $input-border-disabled !default;
-$input-disabled-color: $input-border !default;
-$input-disabled-opacity: 0.5 !default;
-$input-disabled-placeholder-color: $input-color-placeholder !default;
+$input-color-disabled: $input-border !default;
+$input-color-placeholder-disabled: $input-color-placeholder !default;
+$input-opacity-disabled: 0.5 !default;
 
 $input-label-color: $brand-default !default;
 $input-label-disabled-opacity: 0.5 !default;

--- a/src/scss/atlas-theme/variables/_forms.scss
+++ b/src/scss/atlas-theme/variables/_forms.scss
@@ -64,7 +64,6 @@ $input-color-placeholder-disabled: $input-color-placeholder !default;
 $input-opacity-disabled: 0.5 !default;
 
 $input-label-color: $brand-default !default;
-$input-label-disabled-opacity: 0.5 !default;
 $input-label-focus-color: $input-color-focus !default;
 
 $input-readonly-bg: #FAFAFA !default;

--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -125,7 +125,7 @@ label,
 fieldset[disabled] label,
 label.disabled,
 .control-label.disabled {
-	opacity: $input-label-disabled-opacity;
+	opacity: $input-opacity-disabled;
 }
 
 fieldset[disabled] label {

--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -138,17 +138,17 @@ fieldset[disabled] label {
 .form-control {
 	fieldset[disabled] &,
 	&[disabled] {
-		border-color: $input-disabled-border;
-		color: $input-disabled-color;
-		opacity: $input-disabled-opacity;
+		border-color: $input-border-disabled;
+		color: $input-color-disabled;
+		opacity: $input-opacity-disabled;
 
-		@include placeholder($input-disabled-placeholder-color);
+		@include placeholder($input-color-placeholder-disabled);
 	}
 }
 
 .form-control[disabled] > option {
 	@media (-webkit-min-device-pixel-ratio: 0) { // Webkit only
-		color: $input-disabled-color;
+		color: $input-color-disabled;
 	}
 }
 

--- a/src/scss/lexicon-base/variables/_forms.scss
+++ b/src/scss/lexicon-base/variables/_forms.scss
@@ -15,7 +15,6 @@ $input-color-placeholder-disabled: null !default;
 $input-opacity-disabled: null !default;
 
 $input-label-color: null !default;
-$input-label-disabled-opacity: null !default;
 $input-label-focus-color: null !default;
 $input-label-font-size: null !default;
 $input-label-font-weight: null !default;

--- a/src/scss/lexicon-base/variables/_forms.scss
+++ b/src/scss/lexicon-base/variables/_forms.scss
@@ -9,10 +9,10 @@ $input-group-constrain-line-height: $input-height-base - $input-border-top-width
 $input-group-constrain-lg-line-height: $input-height-large - $input-border-top-width - $input-border-bottom-width !default;
 $input-group-constrain-sm-line-height: $input-height-small - $input-border-top-width - $input-border-bottom-width !default;
 
-$input-disabled-border: null !default;
-$input-disabled-color: null !default;
-$input-disabled-opacity: null !default;
-$input-disabled-placeholder-color: null !default;
+$input-border-disabled: null !default;
+$input-color-disabled: null !default;
+$input-color-placeholder-disabled: null !default;
+$input-opacity-disabled: null !default;
 
 $input-label-color: null !default;
 $input-label-disabled-opacity: null !default;


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/form-elements/#disabled-inputs

Hey @natecavanaugh, I decided to rename some variables I added two commits ago to match Bootstrap's naming pattern since they are keeping it in BS4. I also removed a variable I added a commit ago? Opacity on the label cascades to the input when input is nested in label, two different values cause styling issues.