### PR TITLE
Fix: #331 Atlas Checkbox and Radio Label element should have position relative so the input will stay inline with label

### DIFF
--- a/src/scss/atlas-theme/variables/_forms.scss
+++ b/src/scss/atlas-theme/variables/_forms.scss
@@ -37,7 +37,7 @@ $input-mobile-height-base: 40px !default;
 $input-mobile-height-large: 48px !default;
 $input-mobile-height-small: 32px !default;
 
-$input-checkbox-label-line-height: 20px !default;
+$input-checkbox-label-line-height: $line-height-computed !default;
 
 $form-group-margin-bottom: 20px !default;
 

--- a/src/scss/atlas-theme/variables/_forms.scss
+++ b/src/scss/atlas-theme/variables/_forms.scss
@@ -37,6 +37,8 @@ $input-mobile-height-base: 40px !default;
 $input-mobile-height-large: 48px !default;
 $input-mobile-height-small: 32px !default;
 
+$input-checkbox-label-line-height: 20px !default;
+
 $form-group-margin-bottom: 20px !default;
 
 // Skin

--- a/src/scss/atlas-theme/variables/_globals.scss
+++ b/src/scss/atlas-theme/variables/_globals.scss
@@ -25,6 +25,8 @@ $font-size-desktop-h5: floor(($font-size-desktop-base / 1.1428)) !default; // At
 $font-size-desktop-h6: floor(($font-size-desktop-base / 1.2307)) !default; // Atlas 13px
 
 $line-height-base: 1.428571429 !default;
+$line-height-computed: floor(($font-size-base * $line-height-base)) !default;
+
 $headings-line-height: 1.2 !default;
 
 $padding-base-vertical: 6px !default;

--- a/src/scss/atlas-theme/variables/_management-bar.scss
+++ b/src/scss/atlas-theme/variables/_management-bar.scss
@@ -6,7 +6,7 @@ $management-bar-border-right-width: 0 !default;
 $management-bar-border-top-width: 0 !default;
 
 $management-bar-height: $navbar-height !default;
-$management-bar-link-line-height: floor($font-size-base * $line-height-base) !default;
+$management-bar-link-line-height: $line-height-computed !default;
 
 $management-bar-margin-bottom: 0 !default;
 

--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -186,6 +186,7 @@ fieldset[disabled] label {
 		label {
 			font-weight: 500;
 			padding-left: 25px;
+			position: relative;
 
 			@media (-webkit-min-device-pixel-ratio: 0) {
 				padding-left: 20px;

--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -184,7 +184,7 @@ fieldset[disabled] label {
 	.checkbox,
 	.radio {
 		label {
-			font-weight: 500;
+			font-weight: $input-label-font-weight;
 			line-height: $input-checkbox-label-line-height;
 			padding-left: 25px;
 			position: relative;

--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -185,6 +185,7 @@ fieldset[disabled] label {
 	.radio {
 		label {
 			font-weight: 500;
+			line-height: $input-checkbox-label-line-height;
 			padding-left: 25px;
 			position: relative;
 


### PR DESCRIPTION
http://liferay.github.io/lexicon/content/form-elements/#checkboxes-and-radios-no-extra-mark-up